### PR TITLE
Change src file extensions to F90

### DIFF
--- a/src/ppr_1d.F90
+++ b/src/ppr_1d.F90
@@ -1,0 +1,3 @@
+!-- an alternative to building with the -cpp compile flag 
+
+#   include "ppr_1d.f90"


### PR DESCRIPTION
The file extension of the main routine `ppr_1d.f90` needed to be F90 in order for cmake to recognize the c-style `# include` lines. Since the library is in active use, a copy of `ppr_1d` was created with the F90 extension. 