### PR TITLE
Clean-up fortran support: *.f90, *.F90; KIND=DP, etc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+# fortran binaries
+*
+!/**/
+!*.*
+*.mod
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,30 @@
+language: fortran
+matrix:
+  include:
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - gcc-8
+            - gfortran-8
+      script:
+        - gfortran --version
+        - cd examples
+        - gfortran -pedantic -cpp -O3 -flto ex_1.f90 -o ex_1
+        - ./ex_1
+        - gfortran -pedantic -O3 -flto ex_1.F90 -o ex_1
+        - ./ex_1
+        - gfortran -pedantic -cpp -O3 -flto ex_2.f90 -o ex_2
+        - ./ex_2
+        - gfortran -pedantic -cpp -O3 -flto ex_3.f90 -o ex_3
+        - ./ex_3
+        - gfortran -pedantic -cpp -O3 -flto ex_4.f90 -o ex_4
+        - ./ex_4
+        - gfortran -pedantic -cpp -O3 -flto ex_5.f90 -o ex_5
+        - ./ex_5
+        - gfortran -pedantic -cpp -O3 -flto ex_6.f90 -o ex_6
+        - ./ex_6
+        - gfortran -pedantic -cpp -O3 -flto ex_7.f90 -o ex_7
+        - ./ex_7

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,21 +10,22 @@ matrix:
             - gcc-8
             - gfortran-8
       script:
-        - gfortran --version
-        - cd examples
-        - gfortran -pedantic -cpp -O3 -flto ex_1.f90 -o ex_1
+        - export FC=gfortran-8
+        - $FC --version
+        - cd example
+        - $FC -pedantic -cpp -O3 -flto ex_1.f90 -o ex_1
         - ./ex_1
-        - gfortran -pedantic -O3 -flto ex_1.F90 -o ex_1
+        - $FC -pedantic -O3 -flto ex_1.F90 -o ex_1
         - ./ex_1
-        - gfortran -pedantic -cpp -O3 -flto ex_2.f90 -o ex_2
+        - $FC -pedantic -cpp -O3 -flto ex_2.f90 -o ex_2
         - ./ex_2
-        - gfortran -pedantic -cpp -O3 -flto ex_3.f90 -o ex_3
+        - $FC -pedantic -cpp -O3 -flto ex_3.f90 -o ex_3
         - ./ex_3
-        - gfortran -pedantic -cpp -O3 -flto ex_4.f90 -o ex_4
+        - $FC -pedantic -cpp -O3 -flto ex_4.f90 -o ex_4
         - ./ex_4
-        - gfortran -pedantic -cpp -O3 -flto ex_5.f90 -o ex_5
+        - $FC -pedantic -cpp -O3 -flto ex_5.f90 -o ex_5
         - ./ex_5
-        - gfortran -pedantic -cpp -O3 -flto ex_6.f90 -o ex_6
+        - $FC -pedantic -cpp -O3 -flto ex_6.f90 -o ex_6
         - ./ex_6
-        - gfortran -pedantic -cpp -O3 -flto ex_7.f90 -o ex_7
+        - $FC -pedantic -cpp -O3 -flto ex_7.f90 -o ex_7
         - ./ex_7

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ ex_3.f90 ! a smooth profile used for convergence tests
 ex_4.f90 ! multi-tracer re-mapping
 ex_5.f90 ! building high-order interpolants
 ex_6.f90 ! flux-form semi-lagrangian transport (in 1d)
+ex_7.f90 ! as per ex-1, but with negative orientations
 ````
 
 ## `License`

--- a/example/ex_1.F90
+++ b/example/ex_1.F90
@@ -1,0 +1,120 @@
+
+!   gfortran -O3 -flto ex_1.F90 -o ex_1
+!   ./ex_1
+
+!   Same as ex_1.f90, but with a capitalised *.F90 to enable
+!   the preprocessor directives without the -cpp flag. 
+!
+
+#   include "../src/ppr_1d.F90"         ! note: *.F90!
+
+    program ex
+
+        use ppr_1d
+
+        implicit none
+
+        integer, parameter :: npos = 31 ! no. edge (old grid) 
+        integer, parameter :: ntmp = 23 ! no. edge (new grid)
+        integer, parameter :: nvar = 1  ! no. variables to remap
+        integer, parameter :: ndof = 1  ! no. FV DoF per cell
+        integer :: ipos
+
+    !------------------------------ position of cell edges !
+        real*8  :: xpos(npos),xtmp(ntmp)
+        real*8  :: xmid
+        
+    !-------------------------------- finite-volume arrays !
+
+    !   Arrays represent a "block" of finite-volume tracers
+    !   to remap. The 1st dim. is the no. of DoF per cell,
+    !   NDOF=1 is a standard finite-volume scheme where the
+    !   data is specified as cell means. NDOF>1 is reserved
+    !   for future use with DG-style schemes. NVAR is the
+    !   number of tracers to remap. Processing tracers in a
+    !   batch is typically more efficient than one-by-one. 
+    !   The last dim. is the no. cells (layers) in the grid.
+
+        real*8  :: init(ndof,nvar,npos-1)
+        real*8  :: ftmp(ndof,nvar,ntmp-1)
+        real*8  :: fdat(ndof,nvar,npos-1)
+
+    !------------------------------ method data-structures !
+        type(rmap_work) :: work
+        type(rmap_opts) :: opts
+        type(rcon_ends) :: bc_l(nvar)
+        type(rcon_ends) :: bc_r(nvar)
+
+    !------------------------------ define a simple domain !
+
+        call linspace(0.d0,1.d0,npos,xpos)
+        call linspace(0.d0,1.d0,ntmp,xtmp)
+
+    !------------------------------ setup some simple data !
+
+        do ipos = +1, npos-1
+
+            xmid = xpos(ipos+0) * 0.5d+0 &
+    &            + xpos(ipos+1) * 0.5d+0
+
+            init(1,1,ipos) = xmid ** 2
+            
+        end do
+
+    !------------------------------ specify method options !
+
+        opts%edge_meth = p3e_method     ! 3rd-order edge interp.
+        opts%cell_meth = ppm_method     ! PPM method in cells
+        opts%cell_lims = null_limit     ! no slope limiter
+        
+    !------------------------------ set BC.'s at endpoints !
+
+        bc_l%bcopt = bcon_loose         ! "loose" = extrapolate
+        bc_r%bcopt = bcon_loose
+
+    !------------------------------ init. method workspace !
+
+        call work%init(npos,nvar,opts)
+
+    !------------------------------ re-map back-and-forth: !
+
+        fdat = init
+
+        do ipos = +1, +1000
+
+    !------------------------------ re-map from dat-to-tmp !
+
+        call rmap1d(npos,ntmp,nvar,ndof, &
+        &           xpos,xtmp,fdat,ftmp, &
+        &           bc_l,bc_r,work,opts)
+
+    !------------------------------ re-map from tmp-to-dat !
+
+        call rmap1d(ntmp,npos,nvar,ndof, &
+        &           xtmp,xpos,ftmp,fdat, &
+        &           bc_l,bc_r,work,opts)
+
+        end do
+
+    !------------------------------ clear method workspace !
+
+        call work%free()
+
+    !------------------------------ dump results to stdout !
+
+        print*,"Cell data: [INIT] [RMAP] "
+
+        do ipos = +1, npos-1
+
+            print *, init(1,1,ipos) &
+        &          , fdat(1,1,ipos)
+
+        end do
+
+        print*,"Conservation defect := " &
+        &     , sum(init) - sum(fdat)
+
+    end program
+
+
+

--- a/example/ex_1.F90
+++ b/example/ex_1.F90
@@ -1,12 +1,13 @@
 
-!   gfortran -O3 -flto ex_1.F90 -o ex_1
+!   gfortran -pedantic -O3 -flto ex_1.F90 -o ex_1
 !   ./ex_1
 
 !   Same as ex_1.f90, but with a capitalised *.F90 to enable
 !   the preprocessor directives without the -cpp flag. 
 !
 
-#   include "../src/ppr_1d.F90"         ! note: *.F90!
+!   note: *.F90!
+#   include "../src/ppr_1d.F90"
 
     program ex
 
@@ -21,8 +22,8 @@
         integer :: ipos
 
     !------------------------------ position of cell edges !
-        real*8  :: xpos(npos),xtmp(ntmp)
-        real*8  :: xmid
+        real(kind=dp) :: xpos(npos),xtmp(ntmp)
+        real(kind=dp) :: xmid
         
     !-------------------------------- finite-volume arrays !
 
@@ -35,9 +36,9 @@
     !   batch is typically more efficient than one-by-one. 
     !   The last dim. is the no. cells (layers) in the grid.
 
-        real*8  :: init(ndof,nvar,npos-1)
-        real*8  :: ftmp(ndof,nvar,ntmp-1)
-        real*8  :: fdat(ndof,nvar,npos-1)
+        real(kind=dp) :: init(ndof,nvar,npos-1)
+        real(kind=dp) :: fdat(ndof,nvar,npos-1)        
+        real(kind=dp) :: ftmp(ndof,nvar,ntmp-1)
 
     !------------------------------ method data-structures !
         type(rmap_work) :: work

--- a/example/ex_1.f90
+++ b/example/ex_1.f90
@@ -1,5 +1,5 @@
 
-!   gfortran -cpp -O3 -flto ex_1.f90 -o ex_1
+!   gfortran -pedantic -cpp -O3 -flto ex_1.f90 -o ex_1
 !   ./ex_1
 
 !   A very simple starting point: remap a quadratic profile
@@ -22,8 +22,8 @@
         integer :: ipos
 
     !------------------------------ position of cell edges !
-        real*8  :: xpos(npos),xtmp(ntmp)
-        real*8  :: xmid
+        real(kind=dp) :: xpos(npos),xtmp(ntmp)
+        real(kind=dp) :: xmid
         
     !-------------------------------- finite-volume arrays !
 
@@ -36,9 +36,9 @@
     !   batch is typically more efficient than one-by-one. 
     !   The last dim. is the no. cells (layers) in the grid.
 
-        real*8  :: init(ndof,nvar,npos-1)
-        real*8  :: ftmp(ndof,nvar,ntmp-1)
-        real*8  :: fdat(ndof,nvar,npos-1)
+        real(kind=dp) :: init(ndof,nvar,npos-1)
+        real(kind=dp) :: fdat(ndof,nvar,npos-1)        
+        real(kind=dp) :: ftmp(ndof,nvar,ntmp-1)
 
     !------------------------------ method data-structures !
         type(rmap_work) :: work

--- a/example/ex_2.f90
+++ b/example/ex_2.f90
@@ -1,5 +1,5 @@
 
-!   gfortran -cpp -O3 -flto ex_2.f90 -o ex_2
+!   gfortran -pedantic -cpp -O3 -flto ex_2.f90 -o ex_2
 !   ./ex_2
 
 !   Test for the monotone limiter: remap a stairstep profile
@@ -15,15 +15,15 @@
 
         implicit none
 
-        integer, parameter :: npos = 47 ! no. edge (old grid) 
-        integer, parameter :: ntmp = 37 ! no. edge (new grid)
+        integer, parameter :: npos = 97 ! no. edge (old grid) 
+        integer, parameter :: ntmp = 77 ! no. edge (new grid)
         integer, parameter :: nvar = 1  ! no. variables to remap
         integer, parameter :: ndof = 1  ! no. FV DoF per cell
         integer :: ipos
 
     !------------------------------ position of cell edges !
-        real*8  :: xpos(npos),xtmp(ntmp)
-        real*8  :: xmid
+        real(kind=dp) :: xpos(npos),xtmp(ntmp)
+        real(kind=dp) :: xmid
         
     !-------------------------------- finite-volume arrays !
 
@@ -36,9 +36,9 @@
     !   batch is typically more efficient than one-by-one. 
     !   The last dim. is the no. cells (layers) in the grid.
 
-        real*8  :: init(ndof,nvar,npos-1)
-        real*8  :: fdat(ndof,nvar,npos-1)        
-        real*8  :: ftmp(ndof,nvar,ntmp-1)
+        real(kind=dp) :: init(ndof,nvar,npos-1)
+        real(kind=dp) :: fdat(ndof,nvar,npos-1)        
+        real(kind=dp) :: ftmp(ndof,nvar,ntmp-1)
         
     !------------------------------ method data-structures !
         type(rmap_work) :: work
@@ -64,7 +64,7 @@
             if (xmid .lt. 0.67d0) then
             init(1,1,ipos) = +2.0d0
             else
-            init(1,1,ipos) = +0.0d0
+            init(1,1,ipos) = -0.5d0 * xmid ** 2
             end if
 
         end do

--- a/example/ex_2.f90
+++ b/example/ex_2.f90
@@ -58,10 +58,10 @@
             xmid = xpos(ipos+0) * 0.5d+0 &
         &        + xpos(ipos+1) * 0.5d+0
 
-            if (xmid .lt. 0.33d0) then
+            if (xmid .lt. 0.075d0) then
             init(1,1,ipos) = +1.0d0
             else &
-            if (xmid .lt. 0.67d0) then
+            if (xmid .lt. 0.80d0) then
             init(1,1,ipos) = +2.0d0
             else
             init(1,1,ipos) = -0.5d0 * xmid ** 2
@@ -74,6 +74,7 @@
         opts%edge_meth = p5e_method     ! 5th-order edge interp.
         opts%cell_meth = pqm_method     ! PQM method in cells
         opts%cell_lims = mono_limit     ! monotone limiter
+       !opts%wall_lims = weno_limit
         
     !------------------------------ set BC.'s at endpoints !
 

--- a/example/ex_3.f90
+++ b/example/ex_3.f90
@@ -1,5 +1,5 @@
 
-!   gfortran -cpp -O3 -flto ex_3.f90 -o ex_3
+!   gfortran -pedantic -cpp -O3 -flto ex_3.f90 -o ex_3
 !   ./ex_3
 
 !   "Convergence" testing: remap a smooth (Gaussian) profile 
@@ -25,8 +25,8 @@
         integer :: ipos
 
     !------------------------------ position of cell edges !
-        real*8  :: xpos(npos),xtmp(ntmp)
-        real*8  :: xdel,xmid
+        real(kind=dp) :: xpos(npos),xtmp(ntmp)
+        real(kind=dp) :: xdel,xmid
         
     !-------------------------------- finite-volume arrays !
 
@@ -39,9 +39,9 @@
     !   batch is typically more efficient than one-by-one. 
     !   The last dim. is the no. cells (layers) in the grid.
 
-        real*8  :: init(ndof,nvar,npos-1)
-        real*8  :: ftmp(ndof,nvar,ntmp-1)
-        real*8  :: fdat(ndof,nvar,npos-1)
+        real(kind=dp) :: init(ndof,nvar,npos-1)
+        real(kind=dp) :: fdat(ndof,nvar,npos-1)        
+        real(kind=dp) :: ftmp(ndof,nvar,ntmp-1)
 
     !------------------------------ method data-structures !
         type(rmap_work) :: work

--- a/example/ex_3.f90
+++ b/example/ex_3.f90
@@ -18,8 +18,8 @@
 
         implicit none
 
-        integer, parameter :: npos = 50 ! no. edge (old grid) 
-        integer, parameter :: ntmp = 40 ! no. edge (new grid)
+        integer, parameter :: npos = 100 ! no. edge (old grid) 
+        integer, parameter :: ntmp = 80 ! no. edge (new grid)
         integer, parameter :: nvar = 1  ! no. variables to remap
         integer, parameter :: ndof = 1  ! no. FV DoF per cell
         integer :: ipos
@@ -52,7 +52,7 @@
     !------------------------------ define a simple domain !
 
         call linspace(0.d0,1.d0,npos,xpos)
-        call linspace(0.d0,1.d0,ntmp,xtmp)
+        call rndspace(0.d0,1.d0,ntmp,xtmp)
 
     !------------------------------ setup some simple data !
 
@@ -70,10 +70,10 @@
 
     !------------------------------ specify method options !
 
-        opts%edge_meth = p5e_method     ! 3rd-order edge interp.
-        opts%cell_meth = pqm_method     ! PPM method in cells
-        opts%cell_lims = null_limit     ! monotone limiter
-        
+        opts%edge_meth = p3e_method     ! 5th-order edge interp.
+        opts%cell_meth = ppm_method     ! PQM method in cells
+        opts%cell_lims = mono_limit     ! monotone limiter
+       
     !------------------------------ set BC.'s at endpoints !
 
         bc_l%bcopt = bcon_loose         ! "loose" = extrapolate

--- a/example/ex_4.f90
+++ b/example/ex_4.f90
@@ -1,5 +1,5 @@
 
-!   gfortran -cpp -O3 -flto ex_4.f90 -o ex_4
+!   gfortran -pedantic -cpp -O3 -flto ex_4.f90 -o ex_4
 !   ./ex_4
 
 !   Test for multi-tracer remapping: remap a set of profiles
@@ -21,8 +21,8 @@
         integer :: ipos
 
     !------------------------------ position of cell edges !
-        real*8  :: xpos(npos),xtmp(ntmp)
-        real*8  :: xdel,xmid
+        real(kind=dp) :: xpos(npos),xtmp(ntmp)
+        real(kind=dp) :: xmid
         
     !-------------------------------- finite-volume arrays !
 
@@ -35,9 +35,9 @@
     !   batch is typically more efficient than one-by-one. 
     !   The last dim. is the no. cells (layers) in the grid.
 
-        real*8  :: init(ndof,nvar,npos-1)
-        real*8  :: ftmp(ndof,nvar,ntmp-1)
-        real*8  :: fdat(ndof,nvar,npos-1)
+        real(kind=dp) :: init(ndof,nvar,npos-1)
+        real(kind=dp) :: fdat(ndof,nvar,npos-1)        
+        real(kind=dp) :: ftmp(ndof,nvar,ntmp-1)
 
     !------------------------------ method data-structures !
         type(rmap_work) :: work

--- a/example/ex_4.f90
+++ b/example/ex_4.f90
@@ -70,8 +70,8 @@
 
     !------------------------------ specify method options !
 
-        opts%edge_meth = p5e_method     ! 5th-order edge interp.
-        opts%cell_meth = pqm_method     ! PQM method in cells
+        opts%edge_meth = p3e_method     ! 5th-order edge interp.
+        opts%cell_meth = ppm_method     ! PQM method in cells
         opts%cell_lims = mono_limit     ! monotone limiter
         
     !------------------------------ set BC.'s at endpoints !

--- a/example/ex_5.f90
+++ b/example/ex_5.f90
@@ -1,5 +1,5 @@
 
-!   gfortran -cpp -O3 -flto ex_5.f90 -o ex_5
+!   gfortran -pedantic -cpp -O3 -flto ex_5.f90 -o ex_5
 !   ./ex_5
 
 !   Assemble high-order interpolants over a uniform domain.
@@ -19,8 +19,8 @@
         integer :: ipos,jpos,mdof
 
     !------------------------------- domain discretisation !
-        real*8  :: xpos(npos),xdel(1)
-        real*8  :: xmid,xhat,xloc,floc
+        real(kind=dp) :: xpos(npos),xdel(1)
+        real(kind=dp) :: xmid,xhat,xloc,floc
         
     !-------------------------------- finite-volume arrays !
 
@@ -33,7 +33,7 @@
     !   batch is typically more efficient than one-by-one. 
     !   The last dim. is the no. cells (layers) in the grid.
 
-        real*8  :: fdat(ndof,nvar,npos-1)
+        real(kind=dp) :: fdat(ndof,nvar,npos-1)
         
     !-------------------------------- reconstruction coeff !
 
@@ -45,9 +45,9 @@
     !   vector assembled at the interpolation points. Basis
     !   vectors can eb assembled via calls to BFUN1D(). 
 
-        real*8  :: fhat(   5,nvar,npos-1)
-        real*8  :: bvec(   5)
-        real*8  :: spos(   5)
+        real(kind=dp) :: fhat(   5,nvar,npos-1)
+        real(kind=dp) :: bvec(   5)
+        real(kind=dp) :: spos(   5)
 
     !------------------------------ method data-structures !
         type(rcon_work) :: work
@@ -93,7 +93,7 @@
 
     !------------------------------ build cell polynomials !
 
-        fhat = 0.d+0
+        fhat = 0.d+0; bvec = 0.d+0; spos = 0.d+0
 
         mdof = ndof1d (opts%cell_meth)
 

--- a/example/ex_5.f90
+++ b/example/ex_5.f90
@@ -13,13 +13,13 @@
 
         implicit none
 
-        integer, parameter :: npos = 43 ! no. edge 
+        integer, parameter :: npos = 37 ! no. edge 
         integer, parameter :: nvar = 1  ! no. variables to build
         integer, parameter :: ndof = 1  ! no. FV DoF per cell
         integer :: ipos,jpos,mdof
 
     !------------------------------- domain discretisation !
-        real(kind=dp) :: xpos(npos),xdel(1)
+        real(kind=dp) :: xpos(npos),xdel(npos-1)
         real(kind=dp) :: xmid,xhat,xloc,floc
         
     !-------------------------------- finite-volume arrays !
@@ -57,7 +57,7 @@
 
     !------------------------------ define a simple domain !
 
-        call linspace(0.d0,1.d0,npos,xpos)
+        call rndspace(0.d0,1.d0,npos,xpos)
         
         xdel(1) = (xpos(npos)&
     &           -  xpos(   1)) / (npos- 1)
@@ -66,6 +66,9 @@
 
         do ipos = +1, npos-1
 
+            xdel(ipos) = xpos(ipos+1) - xpos(ipos)
+            print*, xdel(ipos)
+
             xmid = xpos(ipos+0) * 0.5d+0 &
     &            + xpos(ipos+1) * 0.5d+0
 
@@ -73,13 +76,23 @@
     &   .8d+0 * exp( -75.0d+0 * (xmid - 0.275d+0) ** 2 ) &
     & + .9d+0 * exp(-100.0d+0 * (xmid - 0.500d+0) ** 2 ) &
     & + 1.d+0 * exp(-125.0d+0 * (xmid - 0.725d+0) ** 2 )
+
+
+            if (xmid .lt. 0.075d0) then
+            fdat(1,1,ipos) = +1.0d0
+            else &
+            if (xmid .lt. 0.80d0) then
+            fdat(1,1,ipos) = +2.0d0
+            else
+            fdat(1,1,ipos) = -0.5d0 * xmid ** 2
+            end if
             
         end do
 
     !------------------------------ specify method options !
 
         opts%edge_meth = p5e_method     ! 5th-order edge interp.
-        opts%cell_meth = pqm_method     ! PPM method in cells
+        opts%cell_meth = ppm_method     ! PPM method in cells
         opts%cell_lims = mono_limit     ! monotone limiter
         
     !------------------------------ set BC.'s at endpoints !

--- a/example/ex_6.f90
+++ b/example/ex_6.f90
@@ -1,5 +1,5 @@
 
-!   gfortran -cpp -O3 -flto ex_6.f90 -o ex_6
+!   gfortran -pedantic -cpp -O3 -flto ex_6.f90 -o ex_6
 !   ./ex_6
 
 !   1d scalar transport in a periodic domain. Fluxes are
@@ -25,8 +25,8 @@
         integer :: ipos,il,ir,step
 
     !------------------------------- domain discretisation !
-        real*8  :: xpos(1-halo:npos+halo)
-        real*8  :: xmid,xdel(1),tDEL
+        real(kind=dp) :: xpos(1-halo:npos+halo)
+        real(kind=dp) :: xmid,xdel(1),tDEL
         
     !-------------------------------- finite-volume arrays !
 
@@ -37,12 +37,12 @@
     !   FLUX: edge-wise distribution of upwind fluxes
     !   QDIV: cell-wise distribution of divergence
 
-        real*8  :: init(ndof,nvar,1-halo:npos+halo-1)
-        real*8  :: qbar(ndof,nvar,1-halo:npos+halo-1)
-        logical :: mask(          1-halo:npos+halo-1)
-        real*8  :: uvel(          1-halo:npos+halo)        
-        real*8  :: flux(     nvar,1-halo:npos+halo)        
-        real*8  :: qdiv(     nvar,1-halo:npos+halo-1)
+        real(kind=dp) :: init(ndof,nvar,1-halo:npos+halo-1)
+        real(kind=dp) :: qbar(ndof,nvar,1-halo:npos+halo-1)
+        logical       :: mask(          1-halo:npos+halo-1)
+        real(kind=dp) :: uvel(          1-halo:npos+halo)        
+        real(kind=dp) :: flux(     nvar,1-halo:npos+halo)        
+        real(kind=dp) :: qdiv(     nvar,1-halo:npos+halo-1)
         
 
     !------------------------------ method data-structures !

--- a/example/ex_7.f90
+++ b/example/ex_7.f90
@@ -1,0 +1,123 @@
+
+!   gfortran -cpp -O3 -flto ex_7.f90 -o ex_7
+!   ./ex_7
+
+!   Same as ex_1, but with xdir reversed so that xpos, xnew
+!   become more -ve with increasing array indices.
+!
+
+#   include "../src/ppr_1d.f90"
+
+    program ex
+
+        use ppr_1d
+
+        implicit none
+
+        integer, parameter :: npos = 31 ! no. edge (old grid) 
+        integer, parameter :: ntmp = 23 ! no. edge (new grid)
+        integer, parameter :: nvar = 1  ! no. variables to remap
+        integer, parameter :: ndof = 1  ! no. FV DoF per cell
+        integer :: ipos
+
+    !------------------------------ position of cell edges !
+        real*8  :: xpos(npos),xtmp(ntmp)
+        real*8  :: xmid
+        
+    !-------------------------------- finite-volume arrays !
+
+    !   Arrays represent a "block" of finite-volume tracers
+    !   to remap. The 1st dim. is the no. of DoF per cell,
+    !   NDOF=1 is a standard finite-volume scheme where the
+    !   data is specified as cell means. NDOF>1 is reserved
+    !   for future use with DG-style schemes. NVAR is the
+    !   number of tracers to remap. Processing tracers in a
+    !   batch is typically more efficient than one-by-one. 
+    !   The last dim. is the no. cells (layers) in the grid.
+
+        real*8  :: init(ndof,nvar,npos-1)
+        real*8  :: ftmp(ndof,nvar,ntmp-1)
+        real*8  :: fdat(ndof,nvar,npos-1)
+
+    !------------------------------ method data-structures !
+        type(rmap_work) :: work
+        type(rmap_opts) :: opts
+        type(rcon_ends) :: bc_l(nvar)
+        type(rcon_ends) :: bc_r(nvar)
+
+    !------------------------------ define a simple domain !
+
+        call linspace(0.d0,1.d0,npos,xpos)
+        call linspace(0.d0,1.d0,ntmp,xtmp)
+
+        xpos = xpos * -1.d0
+        xtmp = xtmp * -1.d0
+
+    !------------------------------ setup some simple data !
+
+        do ipos = +1, npos-1
+
+            xmid = xpos(ipos+0) * 0.5d+0 &
+    &            + xpos(ipos+1) * 0.5d+0
+
+            init(1,1,ipos) = xmid ** 2
+            
+        end do
+
+    !------------------------------ specify method options !
+
+        opts%edge_meth = p3e_method     ! 3rd-order edge interp.
+        opts%cell_meth = ppm_method     ! PPM method in cells
+        opts%cell_lims = null_limit     ! no slope limiter
+        
+    !------------------------------ set BC.'s at endpoints !
+
+        bc_l%bcopt = bcon_loose         ! "loose" = extrapolate
+        bc_r%bcopt = bcon_loose
+
+    !------------------------------ init. method workspace !
+
+        call work%init(npos,nvar,opts)
+
+    !------------------------------ re-map back-and-forth: !
+
+        fdat = init
+
+        do ipos = +1, +1000
+
+    !------------------------------ re-map from dat-to-tmp !
+
+        call rmap1d(npos,ntmp,nvar,ndof, &
+        &           xpos,xtmp,fdat,ftmp, &
+        &           bc_l,bc_r,work,opts)
+
+    !------------------------------ re-map from tmp-to-dat !
+
+        call rmap1d(ntmp,npos,nvar,ndof, &
+        &           xtmp,xpos,ftmp,fdat, &
+        &           bc_l,bc_r,work,opts)
+
+        end do
+
+    !------------------------------ clear method workspace !
+
+        call work%free()
+
+    !------------------------------ dump results to stdout !
+
+        print*,"Cell data: [INIT] [RMAP] "
+
+        do ipos = +1, npos-1
+
+            print *, init(1,1,ipos) &
+        &          , fdat(1,1,ipos)
+
+        end do
+
+        print*,"Conservation defect := " &
+        &     , sum(init) - sum(fdat)
+
+    end program
+
+
+

--- a/example/ex_7.f90
+++ b/example/ex_7.f90
@@ -1,5 +1,5 @@
 
-!   gfortran -cpp -O3 -flto ex_7.f90 -o ex_7
+!   gfortran -pedantic -cpp -O3 -flto ex_7.f90 -o ex_7
 !   ./ex_7
 
 !   Same as ex_1, but with xdir reversed so that xpos, xnew
@@ -21,8 +21,8 @@
         integer :: ipos
 
     !------------------------------ position of cell edges !
-        real*8  :: xpos(npos),xtmp(ntmp)
-        real*8  :: xmid
+        real(kind=dp) :: xpos(npos),xtmp(ntmp)
+        real(kind=dp) :: xmid
         
     !-------------------------------- finite-volume arrays !
 
@@ -35,9 +35,9 @@
     !   batch is typically more efficient than one-by-one. 
     !   The last dim. is the no. cells (layers) in the grid.
 
-        real*8  :: init(ndof,nvar,npos-1)
-        real*8  :: ftmp(ndof,nvar,ntmp-1)
-        real*8  :: fdat(ndof,nvar,npos-1)
+        real(kind=dp) :: init(ndof,nvar,npos-1)
+        real(kind=dp) :: fdat(ndof,nvar,npos-1)        
+        real(kind=dp) :: ftmp(ndof,nvar,ntmp-1)
 
     !------------------------------ method data-structures !
         type(rmap_work) :: work
@@ -50,8 +50,8 @@
         call linspace(0.d0,1.d0,npos,xpos)
         call linspace(0.d0,1.d0,ntmp,xtmp)
 
-        xpos = xpos * -1.d0
-        xtmp = xtmp * -1.d0
+        xpos = -1.d0 * xpos
+        xtmp = -1.d0 * xtmp
 
     !------------------------------ setup some simple data !
 

--- a/src/bfun1d.f90
+++ b/src/bfun1d.f90
@@ -31,7 +31,7 @@
     !
     ! Darren Engwirda 
     ! 07-Sep-2016
-    ! de2363 [at] columbia [dot] edu
+    ! d [dot] engwirda [at] gmail [dot] com
     !
     !
 
@@ -50,9 +50,9 @@
         implicit none
         
     !------------------------------------------- arguments !
-        integer, intent( in) :: isel,ndof
-        real*8 , intent( in) :: sval
-        real*8 , intent(out) :: bfun(:)
+        integer      , intent(in)   :: isel,ndof
+        real(kind=dp), intent(in)   :: sval
+        real(kind=dp), intent(out)  :: bfun(:)
         
         select case (isel)
         case (-1)

--- a/src/ffsl1d.f90
+++ b/src/ffsl1d.f90
@@ -30,8 +30,8 @@
     ! FFSL1D.f90: upwind-biased flux-reconstruction scheme.
     !
     ! Darren Engwirda 
-    ! 31-Mar-2019
-    ! de2363 [at] columbia [dot] edu
+    ! 25-Jun-2020
+    ! d [dot] engwirda [at] gmail [dot] com
     !
     !
 
@@ -62,20 +62,20 @@
         implicit none
     
     !------------------------------------------- arguments !
-        integer, intent(in)  :: npos,nvar,ndof
-        class(rmap_work), intent(inout):: work
-        class(rmap_opts), intent(inout):: opts
-        real*8 , intent(in)  :: spac(:)
-        real*8 , intent(in)  :: tDEL
-        logical, intent(in)  :: mask(:)
-        real*8 , intent(in)  :: qbar(:,:,:)
-        real*8 , intent(in)  :: uvel(:)
-        real*8 , intent(out) :: qedg(:,:)
-        class(rcon_ends), intent(in) :: bclo(:)
-        class(rcon_ends), intent(in) :: bchi(:)
+        integer         , intent(in)    :: npos,nvar,ndof
+        class(rmap_work), intent(inout) :: work
+        class(rmap_opts), intent(inout) :: opts
+        real(kind=dp)   , intent(in)    :: spac(:)
+        real(kind=dp)   , intent(in)    :: tDEL
+        logical         , intent(in)    :: mask(:)
+        real(kind=dp)   , intent(in)    :: qbar(:,:,:)
+        real(kind=dp)   , intent(in)    :: uvel(:)
+        real(kind=dp)   , intent(out)   :: qedg(:,:)
+        class(rcon_ends), intent(in)    :: bclo(:)
+        class(rcon_ends), intent(in)    :: bchi(:)
         
     !------------------------------------------- variables !      
-        integer :: head,tail,nprt
+        integer     :: head,tail,nprt
     
         head = +0 ; tail = +0 ; qedg = 0.d+0
     
@@ -232,19 +232,19 @@
         implicit none
         
     !------------------------------------------- arguments !
-        integer, intent(in)  :: npos,nvar,mdof
-        real*8 , intent(in)  :: SPAC(:)
-        real*8 , intent(in)  :: tDEL
-        real*8 , intent(in)  :: uvel(:)
-        real*8 , intent(in)  :: QHAT(:,:,:)
-        real*8 , intent(out) :: qedg(:,:)  
+        integer      , intent(in)   :: npos,nvar,mdof
+        real(kind=dp), intent(in)   :: SPAC(:)
+        real(kind=dp), intent(in)   :: tDEL
+        real(kind=dp), intent(in)   :: uvel(:)
+        real(kind=dp), intent(in)   :: QHAT(:,:,:)
+        real(kind=dp), intent(out)  :: qedg(:,:)  
   
     !------------------------------------------- variables !      
-        integer :: ipos,ivar
-        real*8  :: uCFL,xhat,ss11,ss22,flux
-        real*8  :: vv11(1:5)
-        real*8  :: vv22(1:5)
-        real*8  :: ivec(1:5)
+        integer           :: ipos,ivar
+        real(kind=dp)     :: uCFL,xhat,ss11,ss22,flux
+        real(kind=dp)     :: vv11(1:5)
+        real(kind=dp)     :: vv22(1:5)
+        real(kind=dp)     :: ivec(1:5)
 
     !----------- single-cell, lagrangian-type upwind rcon. !
         

--- a/src/ffsl1d.f90
+++ b/src/ffsl1d.f90
@@ -248,6 +248,8 @@
 
     !----------- single-cell, lagrangian-type upwind rcon. !
         
+        vv11 = 0.d+0; vv22 = 0.d+0; ivec = 0.d+0
+
         do  ipos = +2 , npos - 1
         
             if (uvel(ipos) .gt. +0.d0) then

--- a/src/inv.f90
+++ b/src/inv.f90
@@ -30,8 +30,8 @@
     ! INV.f90: block-wise solution of small linear systems.
     !
     ! Darren Engwirda 
-    ! 25-Mar-2019
-    ! de2363 [at] columbia [dot] edu
+    ! 25-Jun-2020
+    ! d [dot] engwirda [at] gmail [dot] com
     !
     !
 
@@ -41,16 +41,16 @@
         implicit none
 
     !------------------------------------------- arguments !
-        integer, intent( in) :: adim
-        real*8 , intent( in) :: amat(adim,*)
-        integer, intent( in) :: vdim
-        real*8 , intent(out) :: ainv(vdim,*)
-        real*8 , intent(out) :: adet
+        integer      , intent( in) :: adim
+        real(kind=dp), intent( in) :: amat(adim,*)
+        integer      , intent( in) :: vdim
+        real(kind=dp), intent(out) :: ainv(vdim,*)
+        real(kind=dp), intent(out) :: adet
         
     !------------------------------------------- form A^-1 !
 
         adet   = amat(1,1) * amat(2,2) &
-               - amat(1,2) * amat(2,1)
+        &      - amat(1,2) * amat(2,1)
 
         ainv(1,1) =          amat(2,2)
         ainv(1,2) =        - amat(1,2)
@@ -67,14 +67,14 @@
         implicit none
 
     !------------------------------------------- arguments !
-        integer, intent( in) :: adim
-        real*8 , intent( in) :: amat(adim,*)
-        integer, intent( in) :: vdim
-        real*8 , intent(out) :: ainv(vdim,*)
-        real*8 , intent(out) :: adet
+        integer      , intent( in) :: adim
+        real(kind=dp), intent( in) :: amat(adim,*)
+        integer      , intent( in) :: vdim
+        real(kind=dp), intent(out) :: ainv(vdim,*)
+        real(kind=dp), intent(out) :: adet
         
     !------------------------------------------- variables !
-        real*8 :: &
+        real(kind=dp) :: &
         aa2233,aa2332,aa2133,aa2331,aa2132,&
         aa2231,aa1233,aa1332,aa1223,aa1322,&
         aa1133,aa1331,aa1123,aa1321,aa1132,&
@@ -90,9 +90,9 @@
         aa2231 = amat(2,2) * amat(3,1)
 
         adet =  &
-        amat(1,1) *  (aa2233 - aa2332) - &
-	    amat(1,2) *  (aa2133 - aa2331) + &
-	    amat(1,3) *  (aa2132 - aa2231)
+      & amat(1,1) *  (aa2233 - aa2332) - &
+      & amat(1,2) *  (aa2133 - aa2331) + &
+	  & amat(1,3) *  (aa2132 - aa2231)
 
         aa1233 = amat(1,2) * amat(3,3)
         aa1332 = amat(1,3) * amat(3,2)
@@ -129,54 +129,19 @@
         implicit none
 
     !------------------------------------------- arguments !
-        integer, intent(in)    :: adim
-        real*8 , intent(in)    :: amat(adim,*)
-        integer, intent(in)    :: bdim
-        real*8 , intent(in)    :: bmat(bdim,*)
-        real*8 , intent(in)    :: scal
-        integer, intent(in)    :: cdim
-        real*8 , intent(inout) :: cmat(cdim,*)
+        integer      , intent(in)    :: adim
+        real(kind=dp), intent(in)    :: amat(adim,*)
+        integer      , intent(in)    :: bdim
+        real(kind=dp), intent(in)    :: bmat(bdim,*)
+        real(kind=dp), intent(in)    :: scal
+        integer      , intent(in)    :: cdim
+        real(kind=dp), intent(inout) :: cmat(cdim,*)
 
     !-------------------------------- C = C + scal * A * B !
 
-        if (scal .eq. +1.d0) then
-
-        cmat(1,1) = cmat(1,1) & 
-             + ( amat(1,1) * bmat(1,1) &
-               + amat(1,2) * bmat(2,1) )
-        cmat(2,1) = cmat(2,1) & 
-             + ( amat(2,1) * bmat(1,1) &
-               + amat(2,2) * bmat(2,1) )
-
-        cmat(1,2) = cmat(1,2) & 
-             + ( amat(1,1) * bmat(1,2) &
-               + amat(1,2) * bmat(2,2) )
-        cmat(2,2) = cmat(2,2) & 
-             + ( amat(2,1) * bmat(1,2) &
-               + amat(2,2) * bmat(2,2) )
-
-        else &
-        if (scal .eq. -1.d0) then
-
-        cmat(1,1) = cmat(1,1) & 
-             - ( amat(1,1) * bmat(1,1) &
-               + amat(1,2) * bmat(2,1) )
-        cmat(2,1) = cmat(2,1) & 
-             - ( amat(2,1) * bmat(1,1) &
-               + amat(2,2) * bmat(2,1) )
-
-        cmat(1,2) = cmat(1,2) & 
-             - ( amat(1,1) * bmat(1,2) &
-               + amat(1,2) * bmat(2,2) )
-        cmat(2,2) = cmat(2,2) & 
-             - ( amat(2,1) * bmat(1,2) &
-               + amat(2,2) * bmat(2,2) )
-
-        else 
-
         cmat(1,1) = cmat(1,1) + & 
         scal * ( amat(1,1) * bmat(1,1) &
-               + amat(1,2) * bmat(2,1) )
+               + amat(1,2) * bmat(2,1) ) 
         cmat(2,1) = cmat(2,1) + & 
         scal * ( amat(2,1) * bmat(1,1) &
                + amat(2,2) * bmat(2,1) )
@@ -188,8 +153,6 @@
         scal * ( amat(2,1) * bmat(1,2) &
                + amat(2,2) * bmat(2,2) )
 
-        end if
-
         return
 
     end  subroutine
@@ -200,100 +163,15 @@
         implicit none
 
     !------------------------------------------- arguments !
-        integer, intent(in)    :: adim
-        real*8 , intent(in)    :: amat(adim,*)
-        integer, intent(in)    :: bdim
-        real*8 , intent(in)    :: bmat(bdim,*)
-        real*8 , intent(in)    :: scal
-        integer, intent(in)    :: cdim
-        real*8 , intent(inout) :: cmat(cdim,*)
+        integer      , intent(in)    :: adim
+        real(kind=dp), intent(in)    :: amat(adim,*)
+        integer      , intent(in)    :: bdim
+        real(kind=dp), intent(in)    :: bmat(bdim,*)
+        real(kind=dp), intent(in)    :: scal
+        integer      , intent(in)    :: cdim
+        real(kind=dp), intent(inout) :: cmat(cdim,*)
 
     !-------------------------------- C = C + scal * A * B !
-
-        if (scal .eq. +1.d0) then
-
-        cmat(1,1) = cmat(1,1) &
-             + ( amat(1,1) * bmat(1,1) &
-               + amat(1,2) * bmat(2,1) &
-               + amat(1,3) * bmat(3,1) )
-        cmat(2,1) = cmat(2,1) &
-             + ( amat(2,1) * bmat(1,1) &
-               + amat(2,2) * bmat(2,1) &
-               + amat(2,3) * bmat(3,1) )
-        cmat(3,1) = cmat(3,1) &
-             + ( amat(3,1) * bmat(1,1) &
-               + amat(3,2) * bmat(2,1) &
-               + amat(3,3) * bmat(3,1) )
-
-        cmat(1,2) = cmat(1,2) &
-             + ( amat(1,1) * bmat(1,2) &
-               + amat(1,2) * bmat(2,2) &
-               + amat(1,3) * bmat(3,2) )
-        cmat(2,2) = cmat(2,2) &
-             + ( amat(2,1) * bmat(1,2) &
-               + amat(2,2) * bmat(2,2) &
-               + amat(2,3) * bmat(3,2) )
-        cmat(3,2) = cmat(3,2) &
-             + ( amat(3,1) * bmat(1,2) &
-               + amat(3,2) * bmat(2,2) &
-               + amat(3,3) * bmat(3,2) )
-
-        cmat(1,3) = cmat(1,3) &
-             + ( amat(1,1) * bmat(1,3) &
-               + amat(1,2) * bmat(2,3) &
-               + amat(1,3) * bmat(3,3) )
-        cmat(2,3) = cmat(2,3) &
-             + ( amat(2,1) * bmat(1,3) &
-               + amat(2,2) * bmat(2,3) &
-               + amat(2,3) * bmat(3,3) )
-        cmat(3,3) = cmat(3,3) &
-             + ( amat(3,1) * bmat(1,3) &
-               + amat(3,2) * bmat(2,3) &
-               + amat(3,3) * bmat(3,3) )
-
-        else &
-        if (scal .eq. -1.d0) then
-
-        cmat(1,1) = cmat(1,1) &
-             - ( amat(1,1) * bmat(1,1) &
-               + amat(1,2) * bmat(2,1) &
-               + amat(1,3) * bmat(3,1) )
-        cmat(2,1) = cmat(2,1) &
-             - ( amat(2,1) * bmat(1,1) &
-               + amat(2,2) * bmat(2,1) &
-               + amat(2,3) * bmat(3,1) )
-        cmat(3,1) = cmat(3,1) &
-             - ( amat(3,1) * bmat(1,1) &
-               + amat(3,2) * bmat(2,1) &
-               + amat(3,3) * bmat(3,1) )
-
-        cmat(1,2) = cmat(1,2) &
-             - ( amat(1,1) * bmat(1,2) &
-               + amat(1,2) * bmat(2,2) &
-               + amat(1,3) * bmat(3,2) )
-        cmat(2,2) = cmat(2,2) &
-             - ( amat(2,1) * bmat(1,2) &
-               + amat(2,2) * bmat(2,2) &
-               + amat(2,3) * bmat(3,2) )
-        cmat(3,2) = cmat(3,2) &
-             - ( amat(3,1) * bmat(1,2) &
-               + amat(3,2) * bmat(2,2) &
-               + amat(3,3) * bmat(3,2) )
-
-        cmat(1,3) = cmat(1,3) &
-             - ( amat(1,1) * bmat(1,3) &
-               + amat(1,2) * bmat(2,3) &
-               + amat(1,3) * bmat(3,3) )
-        cmat(2,3) = cmat(2,3) &
-             - ( amat(2,1) * bmat(1,3) &
-               + amat(2,2) * bmat(2,3) &
-               + amat(2,3) * bmat(3,3) )
-        cmat(3,3) = cmat(3,3) &
-             - ( amat(3,1) * bmat(1,3) &
-               + amat(3,2) * bmat(2,3) &
-               + amat(3,3) * bmat(3,3) )
-
-        else 
 
         cmat(1,1) = cmat(1,1) + & 
         scal * ( amat(1,1) * bmat(1,1) &
@@ -334,8 +212,6 @@
                + amat(3,2) * bmat(2,3) &
                + amat(3,3) * bmat(3,3) )
 
-        end if
-
         return
 
     end  subroutine
@@ -346,21 +222,21 @@
         implicit none
 
     !------------------------------------------- arguments !
-        integer, intent(in)    :: adim
-        real*8 , intent(in)    :: amat(adim,*)
-        integer, intent(in)    :: vdim
-        real*8 , intent(inout) :: vrhs(vdim,*)
-        integer, intent(in)    :: nrhs
-        real*8 , intent(in)    :: fEPS
-        logical, intent(inout) :: okay
+        integer      , intent(in)    :: adim
+        real(kind=dp), intent(in)    :: amat(adim,*)
+        integer      , intent(in)    :: vdim
+        real(kind=dp), intent(inout) :: vrhs(vdim,*)
+        integer      , intent(in)    :: nrhs
+        real(kind=dp), intent(in)    :: fEPS
+        logical      , intent(inout) :: okay
 
     !------------------------------------------- variables !
-        real*8                 :: ainv(2,2)
-        real*8                 :: adet
-        real*8                 :: vtmp(  2)
-        integer                :: irhs
+        real(kind=dp)                :: ainv(2,2)
+        real(kind=dp)                :: adet
+        real(kind=dp)                :: vtmp(  2)
+        integer                      :: irhs
 
-        integer, parameter     :: LDIM = 2
+        integer, parameter           :: LDIM = 2
 
     !---------------------------------------- calc. inv(A) !
 
@@ -402,21 +278,21 @@
         implicit none
 
     !------------------------------------------- arguments !
-        integer, intent(in)    :: adim
-        real*8 , intent(in)    :: amat(adim,*)
-        integer, intent(in)    :: vdim
-        real*8 , intent(inout) :: vrhs(vdim,*)
-        integer, intent(in)    :: nrhs
-        real*8 , intent(in)    :: fEPS
-        logical, intent(inout) :: okay
+        integer      , intent(in)    :: adim
+        real(kind=dp), intent(in)    :: amat(adim,*)
+        integer      , intent(in)    :: vdim
+        real(kind=dp), intent(inout) :: vrhs(vdim,*)
+        integer      , intent(in)    :: nrhs
+        real(kind=dp), intent(in)    :: fEPS
+        logical      , intent(inout) :: okay
 
     !------------------------------------------- variables !
-        real*8                 :: ainv(3,3)
-        real*8                 :: adet
-        real*8                 :: vtmp(  3)
-        integer                :: irhs
+        real(kind=dp)                :: ainv(3,3)
+        real(kind=dp)                :: adet
+        real(kind=dp)                :: vtmp(  3)
+        integer                      :: irhs
 
-        integer, parameter     :: LDIM = 3
+        integer, parameter           :: LDIM = 3
 
     !---------------------------------------- calc. inv(A) !
 
@@ -468,25 +344,25 @@
         implicit none
 
     !------------------------------------------- arguments !
-        integer, intent(in)    :: adim
-        real*8 , intent(in)    :: amat(adim,*)
-        integer, intent(in)    :: vdim
-        real*8 , intent(inout) :: vrhs(vdim,*)
-        integer, intent(in)    :: nrhs
-        real*8 , intent(in)    :: fEPS
-        logical, intent(inout) :: okay
+        integer      , intent(in)    :: adim
+        real(kind=dp), intent(in)    :: amat(adim,*)
+        integer      , intent(in)    :: vdim
+        real(kind=dp), intent(inout) :: vrhs(vdim,*)
+        integer      , intent(in)    :: nrhs
+        real(kind=dp), intent(in)    :: fEPS
+        logical      , intent(inout) :: okay
 
     !------------------------------------------- variables !
-        real*8                 :: ainv(2,2)
-        real*8                 :: lmat(2,2)
-        real*8                 :: umat(2,2)
-        real*8                 :: smat(2,2)
-        real*8                 :: sinv(2,2)
-        real*8                 :: adet,sdet        
-        real*8                 :: vtmp(  2)
-        integer                :: irhs
+        real(kind=dp)                :: ainv(2,2)
+        real(kind=dp)                :: lmat(2,2)
+        real(kind=dp)                :: umat(2,2)
+        real(kind=dp)                :: smat(2,2)
+        real(kind=dp)                :: sinv(2,2)
+        real(kind=dp)                :: adet,sdet        
+        real(kind=dp)                :: vtmp(  2)
+        integer                      :: irhs
 
-        integer, parameter     :: LDIM = 2
+        integer, parameter           :: LDIM = 2
 
     !---------------------- form a block LDU factorisation !
 
@@ -499,31 +375,22 @@
 
     !---------------------------------------- L = C * A^-1 !
 
-        lmat(1,1) = +0.d0
-        lmat(1,2) = +0.d0
-        lmat(2,1) = +0.d0
-        lmat(2,2) = +0.d0
+        lmat      = +0.d0
 
         call mul_2x2(amat(3,1),adim,ainv,LDIM, &
                     +1.d0,lmat,LDIM)
         
     !---------------------------------------- U = A^-1 * B !       
 
-        umat(1,1) = +0.d0
-        umat(1,2) = +0.d0
-        umat(2,1) = +0.d0
-        umat(2,2) = +0.d0
+        umat      = +0.d0
  
         call mul_2x2(ainv,LDIM,amat(1,3),adim, &
                     +1.d0,umat,LDIM)
         
     !-------------------------------- S = D - C * A^-1 * B !
 
-        smat(1,1) = amat(3,3)
-        smat(1,2) = amat(3,4)
-        smat(2,1) = amat(4,3)
-        smat(2,2) = amat(4,4)
-
+        smat      = amat(3:4,3:4)
+        
         call mul_2x2(lmat,LDIM,amat(1,3),adim, &
                     -1.d0/adet,smat,LDIM)
 
@@ -609,25 +476,25 @@
         implicit none
 
     !------------------------------------------- arguments !
-        integer, intent(in)    :: adim
-        real*8 , intent(in)    :: amat(adim,*)
-        integer, intent(in)    :: vdim
-        real*8 , intent(inout) :: vrhs(vdim,*)
-        integer, intent(in)    :: nrhs
-        real*8 , intent(in)    :: fEPS
-        logical, intent(inout) :: okay
+        integer      , intent(in)    :: adim
+        real(kind=dp), intent(in)    :: amat(adim,*)
+        integer      , intent(in)    :: vdim
+        real(kind=dp), intent(inout) :: vrhs(vdim,*)
+        integer      , intent(in)    :: nrhs
+        real(kind=dp), intent(in)    :: fEPS
+        logical      , intent(inout) :: okay
 
     !------------------------------------------- variables !
-        real*8                 :: ainv(3,3)
-        real*8                 :: lmat(3,3)
-        real*8                 :: umat(3,3)
-        real*8                 :: smat(3,3)
-        real*8                 :: sinv(3,3)
-        real*8                 :: adet,sdet        
-        real*8                 :: vtmp(  3)
-        integer                :: irhs
+        real(kind=dp)                :: ainv(3,3)
+        real(kind=dp)                :: lmat(3,3)
+        real(kind=dp)                :: umat(3,3)
+        real(kind=dp)                :: smat(3,3)
+        real(kind=dp)                :: sinv(3,3)
+        real(kind=dp)                :: adet,sdet        
+        real(kind=dp)                :: vtmp(  3)
+        integer                      :: irhs
 
-        integer, parameter     :: LDIM = 3
+        integer, parameter           :: LDIM = 3
 
     !---------------------- form a block LDU factorisation !
 
@@ -640,52 +507,28 @@
 
     !---------------------------------------- L = C * A^-1 !
 
-        lmat(1,1) = +0.d0
-        lmat(1,2) = +0.d0
-        lmat(1,3) = +0.d0
-        lmat(2,1) = +0.d0
-        lmat(2,2) = +0.d0
-        lmat(2,3) = +0.d0
-        lmat(3,1) = +0.d0
-        lmat(3,2) = +0.d0
-        lmat(3,3) = +0.d0
+        lmat      = +0.d0
 
         call mul_3x3(amat(4,1),adim,ainv,LDIM, &
                     +1.d0,lmat,LDIM)
         
     !---------------------------------------- U = A^-1 * B !       
 
-        umat(1,1) = +0.d0
-        umat(1,2) = +0.d0
-        umat(1,3) = +0.d0
-        umat(2,1) = +0.d0
-        umat(2,2) = +0.d0
-        umat(2,3) = +0.d0
-        umat(3,1) = +0.d0
-        umat(3,2) = +0.d0
-        umat(3,3) = +0.d0
+        umat      = +0.d0
  
         call mul_3x3(ainv,LDIM,amat(1,4),adim, &
                     +1.d0,umat,LDIM)
         
     !-------------------------------- S = D - C * A^-1 * B !
 
-        smat(1,1) = amat(4,4)
-        smat(1,2) = amat(4,5)
-        smat(1,3) = amat(4,6)
-        smat(2,1) = amat(5,4)
-        smat(2,2) = amat(5,5)
-        smat(2,3) = amat(5,6)
-        smat(3,1) = amat(6,4)
-        smat(3,2) = amat(6,5)
-        smat(3,3) = amat(6,6)
-
+        smat      = amat(4:6,4:6)
+        
         call mul_3x3(lmat,LDIM,amat(1,4),adim, &
                     -1.d0/adet,smat,LDIM)
 
         call inv_3x3(smat,LDIM,sinv,LDIM,sdet)
 
-        okay = (abs(adet) .gt. fEPS)
+        okay = (abs(sdet) .gt. fEPS)
         
         if (okay.eqv..false.) return
 

--- a/src/oscl1d.f90
+++ b/src/oscl1d.f90
@@ -30,7 +30,7 @@
     ! OSCL1D.f90: "oscillation-indicators" for WENO interp.
     !
     ! Darren Engwirda 
-    ! 08-Sep-2016
+    ! 25-Oct-2021
     ! d [dot] engwirda [at] gmail [dot] com
     !
     !
@@ -80,15 +80,14 @@
 
     !------------------------------- variable grid-spacing !
 
-            call osclv(npos,nvar,ndof,delx, &
-        &              fdat,oscl,dmin)
+            call osclv(npos,nvar,ndof,delx,dmin, &
+        &              fdat,oscl)
         
         else
 
     !------------------------------- constant grid-spacing !
         
-            call osclc(npos,nvar,ndof,delx, &
-        &              fdat,oscl,dmin)
+            call osclc(npos,nvar,ndof,fdat,oscl)
                 
         end if
 
@@ -97,7 +96,7 @@
     end  subroutine
     
     pure subroutine osclv (npos,nvar,ndof,delx,&
-        &                  fdat,oscl,dmin)
+        &                  dmin,fdat,oscl)
 
     !
     ! *this is the variable grid-spacing variant .
@@ -132,6 +131,8 @@
     !--------------------------------------- centred point !
 
         head = +1 ; tail = npos-1
+
+        if (ndof.lt.1) return
 
         do  ipos = head+1, tail-1
 
@@ -212,8 +213,7 @@
 
     end  subroutine
     
-    pure subroutine osclc (npos,nvar,ndof,delx,&
-        &                  fdat,oscl,dmin)
+    pure subroutine osclc (npos,nvar,ndof,fdat,oscl)
 
     !
     ! *this is the constant grid-spacing variant .
@@ -233,8 +233,6 @@
 
     !------------------------------------------- arguments !
         integer      , intent( in) :: npos,nvar,ndof
-        real(kind=dp), intent( in) :: dmin
-        real(kind=dp), intent( in) :: delx(1)
         real(kind=dp), intent( in) :: fdat(:,:,:)
         real(kind=dp), intent(out) :: oscl(:,:,:)
 
@@ -244,6 +242,8 @@
     !-------------------------------------- centred points !
 
         head = +1; tail = npos - 1
+
+        if (ndof.lt.1) return
 
         do  ipos = 2, npos-2
         do  ivar = 1, nvar-0

--- a/src/oscl1d.f90
+++ b/src/oscl1d.f90
@@ -31,7 +31,7 @@
     !
     ! Darren Engwirda 
     ! 08-Sep-2016
-    ! de2363 [at] columbia [dot] edu
+    ! d [dot] engwirda [at] gmail [dot] com
     !
     !
     
@@ -53,14 +53,14 @@
         implicit none
 
     !------------------------------------------- arguments !
-        integer, intent( in) :: npos,nvar,ndof
-        real*8 , intent( in) :: dmin
-        real*8 , intent( in) :: delx(:)
-        real*8 , intent( in) :: fdat(:,:,:)
-        real*8 , intent(out) :: oscl(:,:,:)
+        integer      , intent(in)   :: npos,nvar,ndof
+        real(kind=dp), intent(in)   :: dmin
+        real(kind=dp), intent(in)   :: delx(:)
+        real(kind=dp), intent(in)   :: fdat(:,:,:)
+        real(kind=dp), intent(out)  :: oscl(:,:,:)
 
     !------------------------------------------- variables !
-        integer :: ivar,ipos
+        integer     :: ivar,ipos
         
         if (npos.lt.3) then
     !------------------------------- at least 3 grid-cells !
@@ -116,22 +116,22 @@
         implicit none
 
     !------------------------------------------- arguments !
-        integer, intent( in) :: npos,nvar,ndof
-        real*8 , intent( in) :: dmin
-        real*8 , intent( in) :: delx(:)
-        real*8 , intent( in) :: fdat(:,:,:)
-        real*8 , intent(out) :: oscl(:,:,:)
+        integer      , intent(in)   :: npos,nvar,ndof
+        real(kind=dp), intent(in)   :: dmin
+        real(kind=dp), intent(in)   :: delx(:)
+        real(kind=dp), intent(in)   :: fdat(:,:,:)
+        real(kind=dp), intent(out)  :: oscl(:,:,:)
 
     !------------------------------------------- variables !
-        integer :: head,tail
-        integer :: ipos,ivar
-        real*8  :: hhll,hhcc,hhrr
-        real*8  :: hhmm,hhrc,hhlc
-        real*8  :: cmat(2,3)
-
-        head = +1 ; tail = npos-1
+        integer                     :: head,tail
+        integer                     :: ipos,ivar
+        real(kind=dp)               :: hhll,hhcc,hhrr
+        real(kind=dp)               :: hhmm,hhrc,hhlc
+        real(kind=dp)               :: cmat(+2,+3)
 
     !--------------------------------------- centred point !
+
+        head = +1 ; tail = npos-1
 
         do  ipos = head+1, tail-1
 
@@ -232,18 +232,18 @@
         implicit none
 
     !------------------------------------------- arguments !
-        integer, intent( in) :: npos,nvar,ndof
-        real*8 , intent( in) :: dmin
-        real*8 , intent( in) :: delx(1)
-        real*8 , intent( in) :: fdat(:,:,:)
-        real*8 , intent(out) :: oscl(:,:,:)
+        integer      , intent( in) :: npos,nvar,ndof
+        real(kind=dp), intent( in) :: dmin
+        real(kind=dp), intent( in) :: delx(1)
+        real(kind=dp), intent( in) :: fdat(:,:,:)
+        real(kind=dp), intent(out) :: oscl(:,:,:)
 
     !------------------------------------------- variables !
-        integer :: head,tail,ipos,ivar
+        integer     :: head,tail,ipos,ivar
         
-        head = +1; tail = npos - 1
-
     !-------------------------------------- centred points !
+
+        head = +1; tail = npos - 1
 
         do  ipos = 2, npos-2
         do  ivar = 1, nvar-0

--- a/src/p1e.f90
+++ b/src/p1e.f90
@@ -31,7 +31,7 @@
     !
     ! Darren Engwirda 
     ! 09-Sep-2016
-    ! de2363 [at] columbia [dot] edu
+    ! d [dot] engwirda [at] gmail [dot] com
     !
     !
 
@@ -60,20 +60,21 @@
         implicit none
 
     !------------------------------------------- arguments !
-        integer, intent( in) :: npos,nvar,ndof
-        real*8 , intent( in) :: delx(:)
-        real*8 , intent( in) :: fdat(:,:,:)
-        type (rcon_ends), intent(in) :: bclo(:)
-        type (rcon_ends), intent(in) :: bchi(:)
-        real*8 , intent(out) :: edge(:,:)
-        real*8 , intent(out) :: dfdx(:,:)
-        real*8 , intent( in) :: dmin
-        class(rcon_opts), intent(in) :: opts
+        integer         , intent(in)    :: npos,nvar,ndof
+        real(kind=dp)   , intent(in)    :: delx(:)
+        real(kind=dp)   , intent(in)    :: fdat(:,:,:)
+        type (rcon_ends), intent(in)    :: bclo(:)
+        type (rcon_ends), intent(in)    :: bchi(:)
+        real(kind=dp)   , intent(out)   :: edge(:,:)
+        real(kind=dp)   , intent(out)   :: dfdx(:,:)
+        real(kind=dp)   , intent(in)    :: dmin
+        class(rcon_opts), intent(in)    :: opts
 
     !------------------------------------------- variables !
-        integer :: ipos,ivar,head,tail
-        real*8  :: dd10
-        real*8  :: delh(-1:+0)
+        integer                         :: ipos,ivar
+        integer                         :: head,tail
+        real(kind=dp)                   :: dd10
+        real(kind=dp)                   :: delh(-1:+0)
 
         head = +2; tail = npos-1
 
@@ -114,9 +115,9 @@
         &       fdat(1,ivar,ipos+0)
 
                 dfdx(ivar,ipos) = &
-        &         - 2.0d+0 *  &
+        &         - 2.00d+00 * &
         &       fdat(1,ivar,ipos-1) &
-        &         + 2.0d+0 *  &
+        &         + 2.00d+00 * &
         &       fdat(1,ivar,ipos+0)
 
                 edge(ivar,ipos) = &
@@ -150,9 +151,9 @@
         &       fdat(1,ivar,ipos+0)
 
                 dfdx(ivar,ipos) = &
-        &         - 2.0d+0 *  &
+        &         - 2.00d+00 * &
         &       fdat(1,ivar,ipos-1) &
-        &         + 2.0d+0 *  &
+        &         + 2.00d+00 * &
         &       fdat(1,ivar,ipos+0)
 
                 edge(ivar,ipos) = &

--- a/src/p3e.f90
+++ b/src/p3e.f90
@@ -94,6 +94,7 @@
         &             opts,dmin)
         end if
 
+        if (ndof.le.0) return
         if (npos.le.4) return
 
     !------ impose value/slope B.C.'s about lower endpoint !

--- a/src/p3e.f90
+++ b/src/p3e.f90
@@ -31,7 +31,7 @@
     !
     ! Darren Engwirda 
     ! 09-Sep-2016
-    ! de2363 [at] columbia [dot] edu
+    ! d [dot] engwirda [at] gmail [dot] com
     !
     !
     
@@ -60,28 +60,29 @@
         implicit none
 
     !------------------------------------------- arguments !
-        integer, intent( in) :: npos,nvar,ndof
-        real*8 , intent( in) :: delx(:)
-        real*8 , intent( in) :: fdat(:,:,:)
-        type (rcon_ends), intent(in) :: bclo(:)
-        type (rcon_ends), intent(in) :: bchi(:)
-        real*8 , intent(out) :: edge(:,:)
-        real*8 , intent(out) :: dfdx(:,:)
-        real*8 , intent( in) :: dmin
-        class(rcon_opts), intent(in) :: opts
+        integer         , intent(in)    :: npos,nvar,ndof
+        real(kind=dp)   , intent(in)    :: delx(:)
+        real(kind=dp)   , intent(in)    :: fdat(:,:,:)
+        type (rcon_ends), intent(in)    :: bclo(:)
+        type (rcon_ends), intent(in)    :: bchi(:)
+        real(kind=dp)   , intent(out)   :: edge(:,:)
+        real(kind=dp)   , intent(out)   :: dfdx(:,:)
+        real(kind=dp)   , intent(in)    :: dmin
+        class(rcon_opts), intent(in)    :: opts
 
     !------------------------------------------- variables !
-        integer :: ipos,ivar,idof,head,tail
-        logical :: okay
-        real*8  :: xhat,fEPS
-        real*8  :: delh(-2:+1)
-        real*8  :: xmap(-2:+2)
-        real*8  :: fhat(+4, nvar)
-        real*8  :: ivec(+4,-2:+2)
-        real*8  :: cmat(+4,+4)
+        integer                         :: ipos,ivar,idof
+        integer                         :: head,tail
+        logical                         :: okay
+        real(kind=dp)                   :: xhat,fEPS
+        real(kind=dp)                   :: delh(-2:+1)
+        real(kind=dp)                   :: xmap(-2:+2)
+        real(kind=dp)                   :: fhat(+4, nvar)
+        real(kind=dp)                   :: ivec(+4,-2:+2)
+        real(kind=dp)                   :: cmat(+4,+4)
         
-        integer, parameter :: NSIZ = +4
-        real*8 , parameter :: ZERO = 1.d-14  
+        integer      , parameter :: NSIZ = +4
+        real(kind=dp), parameter :: ZERO = +1.d-14  
    
         head = +3 ; tail = npos - 2
 
@@ -240,7 +241,7 @@
 
     !------------------------- fallback if system singular !
 
-#           ifdef __PPR_WARNMAT__
+#           ifdef __PPR_PIVOT__
             
             write(*,*) &
     &   "WARNING::P3E - matrix-is-singular!"

--- a/src/p5e.f90
+++ b/src/p5e.f90
@@ -94,6 +94,7 @@
         &             opts,dmin)
         end if
 
+        if (ndof.le.0) return
         if (npos.le.6) return
 
     !------ impose value/slope B.C.'s about lower endpoint !

--- a/src/p5e.f90
+++ b/src/p5e.f90
@@ -31,7 +31,7 @@
     !
     ! Darren Engwirda 
     ! 25-Mar-2019
-    ! de2363 [at] columbia [dot] edu
+    ! d [dot] engwirda [at] gmail [dot] com
     !
     !
 
@@ -60,28 +60,29 @@
         implicit none
 
     !------------------------------------------- arguments !
-        integer, intent( in) :: npos,nvar,ndof
-        real*8 , intent( in) :: delx(:)
-        real*8 , intent( in) :: fdat(:,:,:)
-        type (rcon_ends), intent(in) :: bclo(:)
-        type (rcon_ends), intent(in) :: bchi(:)
-        real*8 , intent(out) :: edge(:,:)
-        real*8 , intent(out) :: dfdx(:,:)
-        real*8 , intent( in) :: dmin
-        class(rcon_opts), intent(in) :: opts
+        integer         , intent(in)    :: npos,nvar,ndof
+        real(kind=dp)   , intent(in)    :: delx(:)
+        real(kind=dp)   , intent(in)    :: fdat(:,:,:)
+        type (rcon_ends), intent(in)    :: bclo(:)
+        type (rcon_ends), intent(in)    :: bchi(:)
+        real(kind=dp)   , intent(out)   :: edge(:,:)
+        real(kind=dp)   , intent(out)   :: dfdx(:,:)
+        real(kind=dp)   , intent(in)    :: dmin
+        class(rcon_opts), intent(in)    :: opts
 
     !------------------------------------------- variables !
-        integer :: ipos,ivar,idof,head,tail
-        logical :: okay        
-        real*8  :: xhat,fEPS
-        real*8  :: delh(-3:+2)
-        real*8  :: xmap(-3:+3)
-        real*8  :: fhat(+6, nvar)
-        real*8  :: ivec(+6,-3:+3)
-        real*8  :: cmat(+6,+6)
+        integer                         :: ipos,ivar,idof
+        integer                         :: head,tail
+        logical                         :: okay        
+        real(kind=dp)                   :: xhat,fEPS
+        real(kind=dp)                   :: delh(-3:+2)
+        real(kind=dp)                   :: xmap(-3:+3)
+        real(kind=dp)                   :: fhat(+6, nvar)
+        real(kind=dp)                   :: ivec(+6,-3:+3)
+        real(kind=dp)                   :: cmat(+6,+6)
         
-        integer, parameter :: NSIZ = +6
-        real*8 , parameter :: ZERO = 1.d-14   
+        integer      , parameter :: NSIZ = +6
+        real(kind=dp), parameter :: ZERO = +1.d-14   
 
         head = +4 ; tail = npos - 3
 
@@ -120,31 +121,31 @@
             do  ivar = 1, nvar
 
                 edge(ivar,ipos) = &
-        &     + ( 1.d0 / 60.d0) * & 
+        &     + ( 1.d+0 / 60.d+0) * & 
         &       fdat(1,ivar,ipos-3) &
-        &     - ( 8.d0 / 60.d0) * &
+        &     - ( 8.d+0 / 60.d+0) * &
         &       fdat(1,ivar,ipos-2) &
-        &     + (37.d0 / 60.d0) * &
+        &     + (37.d+0 / 60.d+0) * &
         &       fdat(1,ivar,ipos-1) &
-        &     + (37.d0 / 60.d0) * &
+        &     + (37.d+0 / 60.d+0) * &
         &       fdat(1,ivar,ipos+0) &
-        &     - ( 8.d0 / 60.d0) * &
+        &     - ( 8.d+0 / 60.d+0) * &
         &       fdat(1,ivar,ipos+1) &
-        &     + ( 1.d0 / 60.d0) * &
+        &     + ( 1.d+0 / 60.d+0) * &
         &       fdat(1,ivar,ipos+2)
             
                 dfdx(ivar,ipos) = &
-        &     - ( 1.d0 / 90.d0) * & 
+        &     - ( 1.d+0 / 90.d+0) * & 
         &       fdat(1,ivar,ipos-3) &
-        &     + ( 5.d0 / 36.d0) * &
+        &     + ( 5.d+0 / 36.d+0) * &
         &       fdat(1,ivar,ipos-2) &
-        &     - (49.d0 / 36.d0) * &
+        &     - (49.d+0 / 36.d+0) * &
         &       fdat(1,ivar,ipos-1) &
-        &     + (49.d0 / 36.d0) * &
+        &     + (49.d+0 / 36.d+0) * &
         &       fdat(1,ivar,ipos+0) &
-        &     - ( 5.d0 / 36.d0) * &
+        &     - ( 5.d+0 / 36.d+0) * &
         &       fdat(1,ivar,ipos+1) &
-        &     + ( 1.d0 / 90.d0) * &
+        &     + ( 1.d+0 / 90.d+0) * &
         &       fdat(1,ivar,ipos+2)
 
                 dfdx(ivar,ipos) = &
@@ -276,7 +277,7 @@
 
     !------------------------- fallback if system singular !
 
-#           ifdef __PPR_WARNMAT__
+#           ifdef __PPR_PIVOT__
             
             write(*,*) &
     &   "WARNING::P5E - matrix-is-singular!"

--- a/src/pbc.f90
+++ b/src/pbc.f90
@@ -31,7 +31,7 @@
     !
     ! Darren Engwirda 
     ! 09-Sep-2016
-    ! de2363 [at] columbia [dot] edu
+    ! d [dot] engwirda [at] gmail [dot] com
     !
     !
 
@@ -60,17 +60,18 @@
         implicit none
 
     !------------------------------------------- arguments !
-        integer, intent( in) :: npos,nvar,ndof
-        real*8 , intent( in) :: delx(:)
-        real*8 , intent( in) :: fdat(:,:,:)
-        real*8 , intent(out) :: edge(:,:)
-        real*8 , intent(out) :: dfdx(:,:)
-        integer, intent( in) :: iend
-        real*8 , intent( in) :: dmin
-        type(rcon_ends), intent(in) :: bcon(:)
+        integer        , intent(in)     :: npos,nvar,ndof
+        real(kind=dp)  , intent(in)     :: delx(:)
+        real(kind=dp)  , intent(in)     :: fdat(:,:,:)
+        real(kind=dp)  , intent(out)    :: edge(:,:)
+        real(kind=dp)  , intent(out)    :: dfdx(:,:)
+        integer        , intent(in)     :: iend
+        real(kind=dp)  , intent(in)     :: dmin
+        type(rcon_ends), intent(in)     :: bcon(:)
 
     !------------------------------------------- variables !
-        integer :: ivar,nlse,nval,nslp
+        integer                         :: ivar
+        integer                         :: nlse,nval,nslp
 
         nlse = 0 ; nval = 0 ; nslp = 0
 
@@ -186,31 +187,31 @@
         implicit none
 
     !------------------------------------------- arguments !
-        integer, intent( in) :: npos,nvar,ndof
-        integer, intent( in) :: bopt
-        real*8 , intent( in) :: delx(:)
-        real*8 , intent( in) :: fdat(:,:,:)
-        real*8 , intent(out) :: edge(:,:)
-        real*8 , intent(out) :: dfdx(:,:)
-        real*8 , intent( in) :: dmin
-        type(rcon_ends), intent(in) :: bcon(:)
+        integer        , intent(in)     :: npos,nvar,ndof
+        integer        , intent(in)     :: bopt
+        real(kind=dp)  , intent(in)     :: delx(:)
+        real(kind=dp)  , intent(in)     :: fdat(:,:,:)
+        real(kind=dp)  , intent(out)    :: edge(:,:)
+        real(kind=dp)  , intent(out)    :: dfdx(:,:)
+        real(kind=dp)  , intent(in)     :: dmin
+        type(rcon_ends), intent(in)     :: bcon(:)
 
     !------------------------------------------- variables !
-        integer :: ivar,idof,isel, &
-        &          head,tail,nsel
-        logical :: okay        
-        real*8  :: xhat
-        real*8  :: delh(-1:+1)
-        real*8  :: xmap(-1:+2)
-        real*8  :: bvec(+3,-1:+2)
-        real*8  :: gvec(+3,-1:+2)
-        real*8  :: cmat(+3,+3)
-        real*8  :: fhat(+3, nvar)
-        real*8  :: eval(-1:+2)
-        real*8  :: gval(-1:+2)
+        integer                         :: ivar,idof,isel
+        integer                         :: head,tail,nsel
+        logical                         :: okay        
+        real(kind=dp)                   :: xhat
+        real(kind=dp)                   :: delh(-1:+1)
+        real(kind=dp)                   :: xmap(-1:+2)
+        real(kind=dp)                   :: bvec(+3,-1:+2)
+        real(kind=dp)                   :: gvec(+3,-1:+2)
+        real(kind=dp)                   :: cmat(+3,+3)
+        real(kind=dp)                   :: fhat(+3, nvar)
+        real(kind=dp)                   :: eval(-1:+2)
+        real(kind=dp)                   :: gval(-1:+2)
         
-        integer, parameter :: NSIZ = +3
-        real*8 , parameter :: ZERO = +1.d-14  
+        integer      , parameter :: NSIZ = +3
+        real(kind=dp), parameter :: ZERO = +1.d-14  
 
         head = +2; tail = npos - 2
 
@@ -386,7 +387,7 @@
 
         if (okay .eqv..false.) then
 
-#       ifdef __PPR_WARNMAT__
+#       ifdef __PPR_PIVOT__
         
         write(*,*) &
         &   "WARNING::LBC-matrix-is-singular!"
@@ -517,31 +518,31 @@
         implicit none
 
     !------------------------------------------- arguments !
-        integer, intent( in) :: npos,nvar,ndof
-        integer, intent( in) :: bopt
-        real*8 , intent( in) :: delx(:)
-        real*8 , intent( in) :: fdat(:,:,:)
-        real*8 , intent(out) :: edge(:,:)
-        real*8 , intent(out) :: dfdx(:,:)
-        real*8 , intent( in) :: dmin
-        type(rcon_ends), intent(in) :: bcon(:)
+        integer        , intent(in)     :: npos,nvar,ndof
+        integer        , intent(in)     :: bopt
+        real(kind=dp)  , intent(in)     :: delx(:)
+        real(kind=dp)  , intent(in)     :: fdat(:,:,:)
+        real(kind=dp)  , intent(out)    :: edge(:,:)
+        real(kind=dp)  , intent(out)    :: dfdx(:,:)
+        real(kind=dp)  , intent(in)     :: dmin
+        type(rcon_ends), intent(in)     :: bcon(:)
 
     !------------------------------------------- variables !
-        integer :: ivar,idof,isel, &
-        &          head,tail,nsel
-        logical :: okay
-        real*8  :: xhat
-        real*8  :: delh(-1:+1)
-        real*8  :: xmap(-1:+2)
-        real*8  :: bvec(+3,-1:+2)
-        real*8  :: gvec(+3,-1:+2)
-        real*8  :: cmat(+3,+3)
-        real*8  :: fhat(+3, nvar)
-        real*8  :: eval(-1:+2)
-        real*8  :: gval(-1:+2)
+        integer                         :: ivar,idof,isel
+        integer                         :: head,tail,nsel
+        logical                         :: okay
+        real(kind=dp)                   :: xhat
+        real(kind=dp)                   :: delh(-1:+1)
+        real(kind=dp)                   :: xmap(-1:+2)
+        real(kind=dp)                   :: bvec(+3,-1:+2)
+        real(kind=dp)                   :: gvec(+3,-1:+2)
+        real(kind=dp)                   :: cmat(+3,+3)
+        real(kind=dp)                   :: fhat(+3, nvar)
+        real(kind=dp)                   :: eval(-1:+2)
+        real(kind=dp)                   :: gval(-1:+2)
 
-        integer, parameter :: NSIZ = +3
-        real*8 , parameter :: ZERO = +1.d-14
+        integer      , parameter :: NSIZ = +3
+        real(kind=dp), parameter :: ZERO = +1.d-14
 
         head = +2; tail = npos - 2
 
@@ -717,7 +718,7 @@
 
         if (okay .eqv..false.) then
 
-#       ifdef __PPR_WARNMAT__
+#       ifdef __PPR_PIVOT__
         
         write(*,*) &
         &   "WARNING::UBC-matrix-is-singular!"

--- a/src/pbc.f90
+++ b/src/pbc.f90
@@ -215,6 +215,8 @@
 
         head = +2; tail = npos - 2
 
+        if (ndof.le.0) return
+
         if (size(delx).gt.+1) then
 
     !------------------ mean grid spacing about ii-th cell !
@@ -545,6 +547,8 @@
         real(kind=dp), parameter :: ZERO = +1.d-14
 
         head = +2; tail = npos - 2
+
+        if (ndof.le.0) return
 
         if (size(delx).gt.+1) then
 

--- a/src/pcm.f90
+++ b/src/pcm.f90
@@ -31,7 +31,7 @@
     !
     ! Darren Engwirda 
     ! 08-Sep-2016
-    ! de2363 [at] columbia [dot] edu
+    ! d [dot] engwirda [at] gmail [dot] com
     !
     !
 
@@ -51,12 +51,12 @@
         implicit none
 
     !------------------------------------------- arguments !
-        integer, intent( in) :: npos,nvar,ndof
-        real*8 , intent(out) :: fhat(:,:,:)
-        real*8 , intent( in) :: fdat(:,:,:)
+        integer      , intent(in)   :: npos,nvar,ndof
+        real(kind=dp), intent(out)  :: fhat(:,:,:)
+        real(kind=dp), intent(in)   :: fdat(:,:,:)
 
     !------------------------------------------- variables !
-        integer:: ipos,ivar,idof
+        integer     :: ipos,ivar,idof
 
         do  ipos = +1, npos - 1
         do  ivar = +1, nvar + 0

--- a/src/plm.f90
+++ b/src/plm.f90
@@ -31,7 +31,7 @@
     !
     ! Darren Engwirda 
     ! 08-Sep-2016
-    ! de2363 [at] columbia [dot] edu
+    ! d [dot] engwirda [at] gmail [dot] com
     !
     !
 
@@ -55,12 +55,12 @@
         implicit none
 
     !------------------------------------------- arguments !
-        integer, intent( in) :: npos,nvar
-        integer, intent( in) :: ndof,ilim
-        real*8 , intent( in) :: dmin
-        real*8 , intent( in) :: delx(:)
-        real*8 , intent(out) :: fhat(:,:,:)
-        real*8 , intent( in) :: fdat(:,:,:)
+        integer      , intent( in) :: npos,nvar
+        integer      , intent( in) :: ndof,ilim
+        real(kind=dp), intent( in) :: dmin
+        real(kind=dp), intent( in) :: delx(:)
+        real(kind=dp), intent(out) :: fhat(:,:,:)
+        real(kind=dp), intent( in) :: fdat(:,:,:)
 
         if (size(delx).gt.+1) then
         
@@ -108,16 +108,17 @@
         implicit none
 
     !------------------------------------------- arguments !
-        integer, intent( in) :: npos,nvar
-        integer, intent( in) :: ndof,ilim
-        real*8 , intent( in) :: dmin
-        real*8 , intent( in) :: delx(:)
-        real*8 , intent(out) :: fhat(:,:,:)
-        real*8 , intent( in) :: fdat(:,:,:)
+        integer      , intent( in) :: npos,nvar
+        integer      , intent( in) :: ndof,ilim
+        real(kind=dp), intent( in) :: dmin
+        real(kind=dp), intent( in) :: delx(:)
+        real(kind=dp), intent(out) :: fhat(:,:,:)
+        real(kind=dp), intent( in) :: fdat(:,:,:)
         
     !------------------------------------------- variables !
-        integer :: ipos,ivar,head,tail
-        real*8  :: dfds(-1:+1)
+        integer                    :: ipos,ivar
+        integer                    :: head,tail
+        real(kind=dp)              :: dfds(-1:+1)
 
         head = +1; tail = npos - 1
 
@@ -216,16 +217,17 @@
         implicit none
 
     !------------------------------------------- arguments !
-        integer, intent( in) :: npos,nvar
-        integer, intent( in) :: ndof,ilim
-        real*8 , intent( in) :: dmin
-        real*8 , intent( in) :: delx(1)
-        real*8 , intent(out) :: fhat(:,:,:)
-        real*8 , intent( in) :: fdat(:,:,:)
+        integer      , intent( in) :: npos,nvar
+        integer      , intent( in) :: ndof,ilim
+        real(kind=dp), intent( in) :: dmin
+        real(kind=dp), intent( in) :: delx(1)
+        real(kind=dp), intent(out) :: fhat(:,:,:)
+        real(kind=dp), intent( in) :: fdat(:,:,:)
         
     !------------------------------------------- variables !
-        integer :: ipos,ivar,head,tail
-        real*8  :: dfds(-1:+1)
+        integer                    :: ipos,ivar
+        integer                    :: head,tail
+        real(kind=dp)              :: dfds(-1:+1)
 
         head = +1; tail = npos - 1
 
@@ -317,14 +319,14 @@
         implicit none
 
     !------------------------------------------- arguments !
-        real*8 , intent( in) :: ffll,ff00,ffrr
-        real*8 , intent( in) :: hhll,hh00,hhrr
-        real*8 , intent(out) :: dfds(-1:+1)
+        real(kind=dp), intent( in) :: ffll,ff00,ffrr
+        real(kind=dp), intent( in) :: hhll,hh00,hhrr
+        real(kind=dp), intent(out) :: dfds(-1:+1)
 
     !------------------------------------------- variables !
-        real*8  :: fell,ferr,scal
+        real(kind=dp)  :: fell,ferr,scal
 
-        real*8 , parameter :: ZERO = 1.d-14
+        real(kind=dp), parameter :: ZERO = 1.d-14
 
     !---------------------------- 2nd-order approximations !
 
@@ -394,13 +396,13 @@
         implicit none
 
     !------------------------------------------- arguments !
-        real*8 , intent( in) :: ffll,ff00,ffrr
-        real*8 , intent(out) :: dfds(-1:+1)
+        real(kind=dp), intent( in) :: ffll,ff00,ffrr
+        real(kind=dp), intent(out) :: dfds(-1:+1)
 
     !------------------------------------------- variables !
-        real*8  :: fell,ferr,scal
+        real(kind=dp)  :: fell,ferr,scal
 
-        real*8 , parameter :: ZERO = 1.d-14
+        real(kind=dp), parameter :: ZERO = 1.d-14
 
     !---------------------------- 2nd-order approximations !
 

--- a/src/ppm.f90
+++ b/src/ppm.f90
@@ -42,8 +42,8 @@
     !
 
     pure subroutine ppm(npos,nvar,ndof,delx, &
-        &               fdat,fhat,edge,oscl, &
-        &               dmin,ilim,wlim,halo)
+        &               fdat,fhat,edge, &
+        &               oscl,ilim,wlim,halo)
 
     !
     ! NPOS  no. edges over grid.
@@ -59,7 +59,6 @@
     !       is an array with SIZE = NVAR-by-NPOS .
     ! OSCL  grid-cell oscil. dof.'s. OSCL is an array with
     !       SIZE = +2  -by-NVAR-by-NPOS-1 .
-    ! DMIN  min. grid-cell spacing thresh . 
     ! ILIM  cell slope-limiting selection .
     ! WLIM  wall slope-limiting selection .
     ! HALO  width of re-con. stencil, symmetric about mid. .
@@ -69,7 +68,6 @@
 
     !------------------------------------------- arguments !
         integer      , intent(in)  :: npos,nvar,ndof
-        real(kind=dp), intent(in)  :: dmin
         real(kind=dp), intent(out) :: fhat(:,:,:)
         real(kind=dp), intent(in)  :: oscl(:,:,:)
         real(kind=dp), intent(in)  :: delx(:)
@@ -99,6 +97,7 @@
         end do
         end if
 
+        if (ndof.le.0) return
         if (npos.le.2) return
 
     !------------------- reconstruct function on each cell !
@@ -130,13 +129,13 @@
             hhll = delx(iill)
             hhrr = delx(iirr)
 
-            call plsv (ffll,hhll,ff00, &
-    &                  hh00,ffrr,hhrr, &
-    &                  dfds)
+            call plsv (dfds,mono_limit, &
+    &                  ffll,hhll,ff00 , &
+    &                  hh00,ffrr,hhrr)
             else
             
-            call plsc (ffll,ff00,ffrr, &
-    &                  dfds)
+            call plsc (dfds,mono_limit, &
+    &                  ffll,ff00,ffrr)
     
             end if
 

--- a/src/ppm.f90
+++ b/src/ppm.f90
@@ -30,8 +30,8 @@
     ! PPM.f90: 1d slope-limited, piecewise parabolic recon.
     !
     ! Darren Engwirda 
-    ! 08-Sep-2016
-    ! de2363 [at] columbia [dot] edu
+    ! 03-Jul-2020
+    ! d [dot] engwirda [at] gmail [dot] com
     !
     !
   
@@ -68,24 +68,24 @@
         implicit none
 
     !------------------------------------------- arguments !
-        integer, intent(in)  :: npos,nvar,ndof
-        real*8 , intent(in)  :: dmin
-        real*8 , intent(out) :: fhat(:,:,:)
-        real*8 , intent(in)  :: oscl(:,:,:)
-        real*8 , intent(in)  :: delx(:)
-        real*8 , intent(in)  :: fdat(:,:,:)
-        real*8 , intent(in)  :: edge(:,:)
-        integer, intent(in)  :: ilim,wlim,halo
+        integer      , intent(in)  :: npos,nvar,ndof
+        real(kind=dp), intent(in)  :: dmin
+        real(kind=dp), intent(out) :: fhat(:,:,:)
+        real(kind=dp), intent(in)  :: oscl(:,:,:)
+        real(kind=dp), intent(in)  :: delx(:)
+        real(kind=dp), intent(in)  :: fdat(:,:,:)
+        real(kind=dp), intent(in)  :: edge(:,:)
+        integer      , intent(in)  :: ilim,wlim,halo
 
     !------------------------------------------- variables !
-        integer :: ipos,ivar,iill,iirr,head,tail
-        real*8  :: ff00,ffll,ffrr,hh00,hhll,hhrr
-        integer :: mono
-        real*8  :: fell,ferr
-        real*8  :: dfds(-1:+1)
-        real*8  :: wval(+1:+2)
-        real*8  :: uhat(+1:+3)
-        real*8  :: lhat(+1:+3)
+        integer       :: ipos,ivar,iill,iirr,head,tail
+        real(kind=dp) :: ff00,ffll,ffrr,hh00,hhll,hhrr
+        integer       :: mono
+        real(kind=dp) :: fell,ferr
+        real(kind=dp) :: dfds(-1:+1)
+        real(kind=dp) :: wval(+1:+2)
+        real(kind=dp) :: uhat(+1:+3)
+        real(kind=dp) :: lhat(+1:+3)
         
         head = +1; tail = npos - 1
 
@@ -241,16 +241,16 @@
         implicit none
 
     !------------------------------------------- arguments !
-        real*8 , intent(in)    :: ff00
-        real*8 , intent(in)    :: ffll,ffrr
-        real*8 , intent(inout) :: fell,ferr
-        real*8 , intent(in)    :: dfds(-1:+1)
-        real*8 , intent(out)   :: uhat(+1:+3)
-        real*8 , intent(out)   :: lhat(+1:+3)
-        integer, intent(out)   :: mono
+        real(kind=dp), intent(in)    :: ff00
+        real(kind=dp), intent(in)    :: ffll,ffrr
+        real(kind=dp), intent(inout) :: fell,ferr
+        real(kind=dp), intent(in)    :: dfds(-1:+1)
+        real(kind=dp), intent(out)   :: uhat(+1:+3)
+        real(kind=dp), intent(out)   :: lhat(+1:+3)
+        integer      , intent(out)   :: mono
           
     !------------------------------------------- variables !
-        real*8  :: turn
+        real(kind=dp)   :: turn,fmid,fmin,fmax
         
         mono  = 0
         
@@ -321,12 +321,23 @@
         turn = -0.5d+0 * lhat(2) &
     &                  / lhat(3)
 
+        fmid = lhat(1) + lhat(2) * turn**1 &
+    &                  + lhat(3) * turn**2
+
+        fmin = min(ffll,ffrr)
+        fmax = max(ffll,ffrr)
+
+        if ((fmid .le. fmax)& 
+    &  .and.(fmid .ge. fmin)) return
+
         if ((turn .ge. -1.d+0)&
     &  .and.(turn .le. +0.d+0)) then
 
         mono =   +2
 
     !--------------------------- push TURN onto lower edge !
+
+        fell =              ffll
 
         ferr =   +3.0d+0  * ff00 &
     &            -2.0d+0  * fell
@@ -347,7 +358,9 @@
         mono =   +2
 
     !--------------------------- push TURN onto upper edge !
-    
+
+        ferr =              ffrr
+
         fell =   +3.0d+0  * ff00 &
     &            -2.0d+0  * ferr
 

--- a/src/ppr_1d.F90
+++ b/src/ppr_1d.F90
@@ -1,0 +1,7 @@
+
+!-- an alternative to buidling w the -cpp compile flag 
+
+#   include "ppr_1d.f90"
+
+
+

--- a/src/ppr_1d.f90
+++ b/src/ppr_1d.f90
@@ -32,19 +32,22 @@
     ! PPR-1D.f90: 1-d piecewise polynomial reconstructions.
     !
     ! Darren Engwirda 
-    ! 31-Mar-2019
-    ! de2363 [at] columbia [dot] edu
+    ! 25-Jun-2020
+    ! d [dot] engwirda [at] gmail [dot] com
     !
     !
 
     implicit none
 
+    integer, parameter      :: sp = kind(+1.e+00)
+    integer, parameter      :: dp = kind(+1.d+00)
+
     !------------------------------------ compile-time def !
 
-!   define __PPR_WARNMAT__
-!   define __PPR_DOTIMER__
+!   define __PPR_PIVOT__
+!   define __PPR_TIMER__
 
-#   ifdef  __PPR_DOTIMER__
+#   ifdef  __PPR_TIMER__
 
 #       define __TIC__                      \
         call system_clock   (ttic,rate)
@@ -63,51 +66,51 @@
 
     !------------------------------------ method selection !
         
-    integer, parameter :: p1e_method = +100
-    integer, parameter :: p3e_method = +101
-    integer, parameter :: p5e_method = +102
+    integer(kind=4), parameter :: p1e_method = +100
+    integer(kind=4), parameter :: p3e_method = +101
+    integer(kind=4), parameter :: p5e_method = +102
 
-    integer, parameter :: pcm_method = +200
-    integer, parameter :: plm_method = +201
-    integer, parameter :: ppm_method = +202
-    integer, parameter :: pqm_method = +203
+    integer(kind=4), parameter :: pcm_method = +200
+    integer(kind=4), parameter :: plm_method = +201
+    integer(kind=4), parameter :: ppm_method = +202
+    integer(kind=4), parameter :: pqm_method = +203
 
-    integer, parameter :: null_limit = +300
-    integer, parameter :: mono_limit = +301
-    integer, parameter :: weno_limit = +302
+    integer(kind=4), parameter :: null_limit = +300
+    integer(kind=4), parameter :: mono_limit = +301
+    integer(kind=4), parameter :: weno_limit = +302
 
-    integer, parameter :: bcon_loose = +400
-    integer, parameter :: bcon_value = +401
-    integer, parameter :: bcon_slope = +402
+    integer(kind=4), parameter :: bcon_loose = +400
+    integer(kind=4), parameter :: bcon_value = +401
+    integer(kind=4), parameter :: bcon_slope = +402
  
     type rmap_tics
     !------------------------------- tCPU timer for RCON1D !
-        integer :: rmap_time
-        integer :: edge_time
-        integer :: cell_time
-        integer :: oscl_time
+        integer(kind=8)             :: rmap_time
+        integer(kind=8)             :: edge_time
+        integer(kind=8)             :: cell_time
+        integer(kind=8)             :: oscl_time
     end type rmap_tics
 
     type rcon_opts
     !------------------------------- parameters for RCON1D !
-        integer :: edge_meth
-        integer :: cell_meth
-        integer :: cell_lims
-        integer :: wall_lims
+        integer(kind=4)             :: edge_meth
+        integer(kind=4)             :: cell_meth
+        integer(kind=4)             :: cell_lims
+        integer(kind=4)             :: wall_lims
     end type rcon_opts
 
     type rcon_ends
     !------------------------------- end-conditions struct !
-        integer :: bcopt
-        real*8  :: value
-        real*8  :: slope
+        integer                     :: bcopt
+        real(kind=dp)               :: value
+        real(kind=dp)               :: slope
     end type rcon_ends
 
     type rcon_work
     !------------------------------- work-space for RCON1D !
-        real*8, allocatable  :: edge_func(:,:)
-        real*8, allocatable  :: edge_dfdx(:,:)
-        real*8, allocatable  :: cell_oscl(:,:,:)
+        real(kind=dp), allocatable  :: edge_func(:,:)
+        real(kind=dp), allocatable  :: edge_dfdx(:,:)
+        real(kind=dp), allocatable  :: cell_oscl(:,:,:)
     contains
         procedure :: init => init_rcon_work
         procedure :: free => free_rcon_work
@@ -119,8 +122,8 @@
 
     type, extends(rcon_work) :: rmap_work
     !------------------------------- work-space for RMAP1D !
-        real*8, allocatable  :: cell_spac(:)
-        real*8, allocatable  :: cell_func(:,:,:)
+        real(kind=dp), allocatable  :: cell_spac(:)
+        real(kind=dp), allocatable  :: cell_func(:,:,:)
     contains
         procedure :: init => init_rmap_work
         procedure :: free => free_rmap_work
@@ -253,28 +256,25 @@
     !------------------------------------------- variables !
         integer  :: rdof
 
-        select case(meth)
     !-------------------------------- edge reconstructions !
-        case (p1e_method)
+        if      (meth.eq.p1e_method) then 
             rdof = +2
-        case (p3e_method)
+        else if (meth.eq.p3e_method) then 
             rdof = +4
-        case (p5e_method)
+        else if (meth.eq.p5e_method) then
             rdof = +6
+
     !-------------------------------- cell reconstructions !
-        case (pcm_method)
+        else if (meth.eq.pcm_method) then
             rdof = +1
-        case (plm_method)
+        else if (meth.eq.plm_method) then
             rdof = +2
-        case (ppm_method)
+        else if (meth.eq.ppm_method) then
             rdof = +3
-        case (pqm_method)
+        else if (meth.eq.pqm_method) then
             rdof = +5
         
-        case default 
-            rdof = +0
-
-        end select
+        end if
         
     end function  ndof1d
 

--- a/src/ppr_1d.f90
+++ b/src/ppr_1d.f90
@@ -32,15 +32,15 @@
     ! PPR-1D.f90: 1-d piecewise polynomial reconstructions.
     !
     ! Darren Engwirda 
-    ! 25-Jun-2020
+    ! 25-Oct-2021
     ! d [dot] engwirda [at] gmail [dot] com
     !
     !
 
     implicit none
 
-    integer, parameter      :: sp = kind(+1.e+00)
-    integer, parameter      :: dp = kind(+1.d+00)
+    integer, parameter      :: sp = kind(+1.0e+00)
+    integer, parameter      :: dp = kind(+1.0d+00)
 
     !------------------------------------ compile-time def !
 
@@ -54,13 +54,14 @@
 
 #       define __TOC__(time, mark)          \
         call system_clock   (ttoc,rate) ;   \
-        if ( present(time)) \
+        if ( present(time) ) \
         time%mark=time%mark+(ttoc-ttic)
     
 #   else
 
 #       define __TIC__
-#       define __TOC__(time, mark)
+#       define __TOC__(time, mark)          \
+        if ( present(time) ) time%mark = + 0
 
 #   endif
 
@@ -153,7 +154,9 @@
         class(rcon_opts) , optional      :: opts
 
     !------------------------------------------- variables !
-        integer :: okay
+        integer :: okay,ndof
+
+        ndof = ndof1d(opts%cell_meth)
 
         allocate(this% &
         &   edge_func(  nvar,npos), &
@@ -273,6 +276,9 @@
             rdof = +3
         else if (meth.eq.pqm_method) then
             rdof = +5
+
+        else
+            rdof = +0               ! default
         
         end if
         

--- a/src/pqm.f90
+++ b/src/pqm.f90
@@ -31,7 +31,7 @@
     !
     ! Darren Engwirda 
     ! 08-Sep-2016
-    ! de2363 [at] columbia [dot] edu
+    ! d [dot] engwirda [at] gmail [dot] com
     !
     !
 
@@ -71,27 +71,27 @@
         implicit none
         
     !------------------------------------------- arguments !
-        integer, intent(in)  :: npos,nvar,ndof
-        integer, intent(in)  :: ilim,wlim,halo
-        real*8 , intent(in)  :: dmin
-        real*8 , intent(out) :: fhat(:,:,:)
-        real*8 , intent(in)  :: oscl(:,:,:)
-        real*8 , intent(in)  :: delx(:)
-        real*8 , intent(in)  :: fdat(:,:,:)
-        real*8 , intent(in)  :: edge(:,:)
-        real*8 , intent(in)  :: dfdx(:,:)
+        integer      , intent(in)  :: npos,nvar,ndof
+        integer      , intent(in)  :: ilim,wlim,halo
+        real(kind=dp), intent(in)  :: dmin
+        real(kind=dp), intent(out) :: fhat(:,:,:)
+        real(kind=dp), intent(in)  :: oscl(:,:,:)
+        real(kind=dp), intent(in)  :: delx(:)
+        real(kind=dp), intent(in)  :: fdat(:,:,:)
+        real(kind=dp), intent(in)  :: edge(:,:)
+        real(kind=dp), intent(in)  :: dfdx(:,:)
 
     !------------------------------------------- variables !
-        integer :: ipos,ivar,iill,iirr,head,tail
-        real*8  :: ff00,ffll,ffrr,hh00,hhll,hhrr
-        real*8  :: xhat
-        integer :: mono
-        real*8  :: fell,ferr
-        real*8  :: dell,derr
-        real*8  :: dfds(-1:+1)
-        real*8  :: uhat(+1:+5)
-        real*8  :: lhat(+1:+5)
-        real*8  :: wval(+1:+2)
+        integer       :: ipos,ivar,iill,iirr,head,tail
+        real(kind=dp) :: ff00,ffll,ffrr,hh00,hhll,hhrr
+        real(kind=dp) :: xhat
+        integer       :: mono
+        real(kind=dp) :: fell,ferr
+        real(kind=dp) :: dell,derr
+        real(kind=dp) :: dfds(-1:+1)
+        real(kind=dp) :: uhat(+1:+5)
+        real(kind=dp) :: lhat(+1:+5)
+        real(kind=dp) :: wval(+1:+2)
         
         head = +1; tail = npos - 1
 
@@ -266,19 +266,20 @@
         implicit none
 
     !------------------------------------------- arguments !
-        real*8 , intent(in)    :: ff00
-        real*8 , intent(in)    :: ffll,ffrr
-        real*8 , intent(inout) :: fell,ferr
-        real*8 , intent(inout) :: dell,derr
-        real*8 , intent(in)    :: dfds(-1:+1)
-        real*8 , intent(out)   :: uhat(+1:+5)
-        real*8 , intent(out)   :: lhat(+1:+5)
-        integer, intent(out)   :: mono
+        real(kind=dp), intent(in)    :: ff00
+        real(kind=dp), intent(in)    :: ffll,ffrr
+        real(kind=dp), intent(inout) :: fell,ferr
+        real(kind=dp), intent(inout) :: dell,derr
+        real(kind=dp), intent(in)    :: dfds(-1:+1)
+        real(kind=dp), intent(out)   :: uhat(+1:+5)
+        real(kind=dp), intent(out)   :: lhat(+1:+5)
+        integer      , intent(out)   :: mono
           
     !------------------------------------------- variables !
-        integer :: turn
-        real*8  :: grad, iflx(+1:+2)
-        logical :: haveroot
+        integer         :: turn
+        real(kind=dp)   :: grad
+        real(kind=dp)   :: iflx(+1:+2)
+        logical         :: haveroot
         
     !-------------------------------- "null" slope-limiter !
         
@@ -330,15 +331,7 @@
             mono = +1
        
             fell = ff00 - dfds(0)
-
-        end if
-
-        if (dell * dfds(0) .lt. 0.d+0) then
-
-            mono = +1
-
-            dell = dfds(0)
- 
+            
         end if
 
         if((ffrr - ferr) * &
@@ -347,15 +340,7 @@
             mono = +1
 
             ferr = ff00 + dfds(0)
-         
-        end if
-
-        if (derr * dfds(0) .lt. 0.d+0) then
-
-            mono = +1
-
-            derr = dfds(0)
-
+            
         end if
     
     !----------------------------------- limit cell values !
@@ -461,9 +446,9 @@
     &- ( 1.d+0 /  3.d+0) * ferr &
     &- ( 4.d+0 /  3.d+0) * fell
 
-        if (dell*dfds(+0) .lt. 0.d+0) then
+        if (dell*dfds(-0) .lt. 0.d+0) then
 
-        dell =   0.d+0
+        dell = dfds(-0)
 
         ferr = &
     &+ ( 5.d+0 /  1.d+0) * ff00 &
@@ -475,7 +460,7 @@
         else &
     &   if (derr*dfds(+0) .lt. 0.d+0) then
 
-        derr =   0.d+0
+        derr = dfds(+0)
 
         fell = &
     &+ ( 5.d+0 /  2.d+0) * ff00 &
@@ -522,9 +507,9 @@
     &- ( 2.d+0 /  1.d+0) * ferr &
     &- ( 3.d+0 /  1.d+0) * fell
 
-        if (dell*dfds(+0) .lt. 0.d+0) then
+        if (dell*dfds(-0) .lt. 0.d+0) then
 
-        dell =   0.d+0
+        dell = dfds(-0)
 
         ferr = &
     &+ ( 5.d+0 /  2.d+0) * ff00 &
@@ -536,7 +521,7 @@
         else & 
     &   if (derr*dfds(+0) .lt. 0.d+0) then
 
-        derr =   0.d+0
+        derr = dfds(+0)
 
         fell = &
     &+ ( 5.d+0 /  1.d+0) * ff00 &

--- a/src/rcon1d.f90
+++ b/src/rcon1d.f90
@@ -31,7 +31,7 @@
     !
     ! Darren Engwirda 
     ! 07-Sep-2016
-    ! de2363 [at] columbia [dot] edu
+    ! d [dot] engwirda [at] gmail [dot] com
     !
     !
     
@@ -59,23 +59,23 @@
         implicit none
 
     !------------------------------------------- arguments !
-        integer, intent( in) :: npos,nvar,ndof
-        class(rcon_work), intent(inout):: work
-        class(rcon_opts), intent(in)   :: opts
-        real*8 , intent( in) :: delx(:)
-        real*8 , intent(out) :: fhat(:,:,:)
-        real*8 , intent( in) :: fdat(:,:,:)
-        type (rcon_ends), intent(in) :: bclo(:)
-        type (rcon_ends), intent(in) :: bchi(:)
+        integer, intent(in)             :: npos,nvar,ndof
+        class(rcon_work), intent(inout) :: work
+        class(rcon_opts), intent(in)    :: opts
+        real(kind=dp)   , intent(in)    :: delx(:)
+        real(kind=dp)   , intent(out)   :: fhat(:,:,:)
+        real(kind=dp)   , intent(in)    :: fdat(:,:,:)
+        type (rcon_ends), intent(in)    :: bclo(:)
+        type (rcon_ends), intent(in)    :: bchi(:)
         type (rmap_tics), &
-        &   intent(inout) , optional :: tCPU
+        &   intent(inout) , optional    :: tCPU
 
     !------------------------------------------- variables !
-        integer :: halo,ipos
-        real*8  :: dmin,dmid
+        integer                         :: halo,ipos
+        real(kind=dp)                   :: dmin,dmid
 
 #       ifdef __PPR_TIMER__
-        integer(kind=8) :: ttic,ttoc,rate
+        integer(kind=8)                 :: ttic,ttoc,rate
 #       endif
 
         if (ndof.lt.1) return
@@ -156,7 +156,7 @@
      
         end if
     
-        __TOC__(time,oscl_time)
+        __TOC__(tCPU,oscl_time)
 
     !-------------------------- compute grid-cell profiles !
 

--- a/src/rcon1d.f90
+++ b/src/rcon1d.f90
@@ -172,7 +172,6 @@
     !------------------------------------ 2nd-order method !
             call plm(npos,nvar,ndof, &
             &        delx,fdat,fhat, &
-            &        dmin,&
             &        opts%cell_lims)
 
             case(ppm_method)
@@ -181,7 +180,6 @@
             &        delx,fdat,fhat, &
             &        work%edge_func, &
             &        work%cell_oscl, &
-            &        dmin,&
             &        opts%cell_lims, &
             &        opts%wall_lims, &
             &        halo )
@@ -193,7 +191,6 @@
             &        work%edge_func, &
             &        work%edge_dfdx, &
             &        work%cell_oscl, &
-            &        dmin,&
             &        opts%cell_lims, &
             &        opts%wall_lims, &
             &        halo )

--- a/src/rmap1d.f90
+++ b/src/rmap1d.f90
@@ -77,7 +77,7 @@
 
         if (xpos(npos) .ge. xpos(1)) then       ! +ve xdir
 
-        call _map1d(npos,nnew,nvar,ndof, &
+        call xmap1d(npos,nnew,nvar,ndof, &
         &           xpos(+1:npos:+1), &
         &           xnew(+1:nnew:+1), &
         &           fdat(:,:,+1:npos-1:+1), &
@@ -86,7 +86,7 @@
 
         else                                    ! -ve xdir
 
-        call _map1d(npos,nnew,nvar,ndof, &
+        call xmap1d(npos,nnew,nvar,ndof, &
         &           xpos(npos:+1:-1), &
         &           xnew(nnew:+1:-1), &
         &           fdat(:,:,npos-1:+1:-1), &
@@ -99,7 +99,7 @@
 
     end  subroutine
 
-    subroutine _map1d(npos,nnew,nvar,ndof,xpos, &
+    subroutine xmap1d(npos,nnew,nvar,ndof,xpos, &
         &             xnew,fdat,fnew,bclo,bcup, &
         &             work,opts,tCPU)
 
@@ -312,6 +312,8 @@
 
         kmin = +1 ; kmax = +1
         pos0 = +1 ; pos1 = +1
+
+        vvlo = 0.d+0; vvhi = 0.d+0; ivec = 0.d+0
 
         do  kpos = +1, nnew-1
 

--- a/src/root1d.f90
+++ b/src/root1d.f90
@@ -31,7 +31,7 @@
     !
     ! Darren Engwirda 
     ! 25-Mar-2019
-    ! de2363 [at] columbia [dot] edu
+    ! d [dot] engwirda [at] gmail [dot] com
     !
     !
 
@@ -44,14 +44,14 @@
         implicit none
 
     !------------------------------------------- arguments !
-        real*8 , intent( in) :: aa,bb,cc
-        real*8 , intent(out) :: xx(1:2)
-        logical, intent(out) :: haveroot
+        real(kind=dp), intent(in)   :: aa,bb,cc
+        real(kind=dp), intent(out)  :: xx(1:2)
+        logical      , intent(out)  :: haveroot
 
     !------------------------------------------- variables !
-        real*8 :: sq,ia,a0,b0,c0,x0
+        real(kind=dp) :: sq,ia,a0,b0,c0,x0
 
-        real*8, parameter :: rt = +1.d-14
+        real(kind=dp), parameter :: rt = +1.d-14
 
         a0 = abs(aa)
         b0 = abs(bb)

--- a/src/util1d.f90
+++ b/src/util1d.f90
@@ -30,7 +30,7 @@
     ! UTIL1D.f90: util. func. for 1-dim. grid manipulation.
     !
     ! Darren Engwirda 
-    ! 25-Jun-2020
+    ! 08-Nov-2021
     ! d [dot] engwirda [at] gmail [dot] com
     !
     !
@@ -138,7 +138,7 @@
         if (present(frac)) then
             move = +frac
         else
-            move = 0.33d0
+            move = 3.0d0 / 8.0d0
         end if
 
         xpos(   1) = xxll
@@ -158,10 +158,8 @@
 
             rand = 2.d0 * (rand-.5d0)
             
-            move = rand *  move
-
             xpos(ipos) = &
-        &       xpos(ipos) + move * xdel         
+        &       xpos(ipos) + (move * rand * xdel)         
 
         end do
 

--- a/src/util1d.f90
+++ b/src/util1d.f90
@@ -30,10 +30,55 @@
     ! UTIL1D.f90: util. func. for 1-dim. grid manipulation.
     !
     ! Darren Engwirda 
-    ! 31-Mar-2019
-    ! de2363 [at] columbia [dot] edu
+    ! 25-Jun-2020
+    ! d [dot] engwirda [at] gmail [dot] com
     !
     !
+
+    function sum_kbn(xvec) result(ssum)
+
+    ! 
+    ! XVEC  array to sum.
+    ! SSUM  sum(XVEC), via Kahan-Babuska-Neumaier sum .
+    !
+
+        implicit none
+
+        real(kind=dp), intent(in)   :: xvec(:)
+
+        integer         :: ipos
+        real(kind=dp)   :: ssum,serr,stmp
+
+    !------------------------------- compensated summation !
+
+        ssum = 0.d0; serr = 0.d0
+
+        do  ipos = +1, size(xvec) - 0
+    
+            stmp = ssum + xvec(ipos)
+
+            if (abs(ssum) &
+        &       .ge. abs(xvec(ipos))) then
+
+            serr = &
+        &   serr + ((ssum-stmp)+xvec(ipos))
+
+            else
+
+            serr = &
+        &   serr + ((xvec(ipos)-stmp)+ssum)
+
+            end if
+
+            ssum = stmp
+        
+        end do
+
+        ssum = ssum + serr
+
+        return
+
+    end function
 
     subroutine linspace(xxll,xxuu,npos,xpos)
 
@@ -46,12 +91,12 @@
 
         implicit none
 
-        real*8 , intent(in)  :: xxll,xxuu
-        integer, intent(in)  :: npos
-        real*8 , intent(out) :: xpos(:)
+        real(kind=dp), intent(in)   :: xxll,xxuu
+        integer      , intent(in)   :: npos
+        real(kind=dp), intent(out)  :: xpos(:)
 
-        integer   :: ipos
-        real*8    :: xdel
+        integer                     :: ipos
+        real(kind=dp)               :: xdel
 
         xpos(   1) = xxll
         xpos(npos) = xxuu
@@ -81,13 +126,14 @@
 
         implicit none
 
-        real*8 , intent(in)  :: xxll,xxuu
-        integer, intent(in)  :: npos
-        real*8 , intent(out) :: xpos(:)
-        real*8 , intent(in), optional :: frac
+        real(kind=dp), intent(in)   :: xxll,xxuu
+        integer      , intent(in)   :: npos
+        real(kind=dp), intent(out)  :: xpos(:)
+        real(kind=dp), intent(in), optional :: frac
 
-        integer   :: ipos
-        real*8    :: xdel,rand,move
+        integer                     :: ipos
+        real(kind=dp)               :: xdel
+        real(kind=dp)               :: rand,move
 
         if (present(frac)) then
             move = +frac

--- a/src/weno1d.f90
+++ b/src/weno1d.f90
@@ -351,7 +351,7 @@
       
     !---------------------------------------- "lower" part !
       
-        delh = 0.d0
+        delh = 0.d0 * delx(1)
 
         do  hpos = ipos-1, imin, -1
         
@@ -380,7 +380,7 @@
       
     !---------------------------------------- "upper" part !     
       
-        delh = 0.d0
+        delh = 0.d0 * delx(1)
         
         do  hpos = ipos+1, imax, +1
         

--- a/src/weno1d.f90
+++ b/src/weno1d.f90
@@ -31,7 +31,7 @@
     !
     ! Darren Engwirda 
     ! 08-Sep-2016
-    ! de2363 [at] columbia [dot] edu
+    ! d [dot] engwirda [at] gmail [dot] com
     !
     !
 
@@ -60,17 +60,17 @@
         implicit none
 
     !------------------------------------------- arguments !
-        integer, intent(in)  :: npos,halo
-        integer, intent(in)  :: ipos,ivar
-        integer, intent(in)  :: wlim
-        real*8 , intent(in)  :: delx(:)
-        real*8 , intent(in)  :: oscl(:,:,:)
-        real*8 , intent(out) :: wval(2)
+        integer      , intent(in)   :: npos,halo
+        integer      , intent(in)   :: ipos,ivar
+        integer      , intent(in)   :: wlim
+        real(kind=dp), intent(in)   :: delx(:)
+        real(kind=dp), intent(in)   :: oscl(:,:,:)
+        real(kind=dp), intent(out)  :: wval(2)
     
     !------------------------------------------- variables !
-        real*8 :: omin,omax,wsum
+        real(kind=dp) :: omin,omax,wsum
         
-        real*8 , parameter :: ZERO = +1.d-16
+        real(kind=dp), parameter :: ZERO = +1.d-16
        
         if (size(delx).gt.+1) then
         
@@ -142,21 +142,21 @@
         implicit none
 
     !------------------------------------------- arguments !
-        integer, intent(in)  :: npos,halo
-        integer, intent(in)  :: ipos,ivar
-        integer, intent(in)  :: wlim
-        real*8 , intent(in)  :: delx(:)
-        real*8 , intent(in)  :: oscl(:,:,:)
-        real*8 , intent(out) :: omin,omax
+        integer      , intent(in)   :: npos,halo
+        integer      , intent(in)   :: ipos,ivar
+        integer      , intent(in)   :: wlim
+        real(kind=dp), intent(in)   :: delx(:)
+        real(kind=dp), intent(in)   :: oscl(:,:,:)
+        real(kind=dp), intent(out)  :: omin,omax
 
     !------------------------------------------- variables !
-        integer :: hpos
-        integer :: head,tail
-        integer :: imin,imax
-        real*8  :: deli,delh
-        real*8  :: hh00,hsqr
-        real*8  :: dfx1,dfx2
-        real*8  :: oval
+        integer                     :: hpos
+        integer                     :: head,tail
+        integer                     :: imin,imax
+        real(kind=dp)               :: deli,delh
+        real(kind=dp)               :: hh00,hsqr
+        real(kind=dp)               :: dfx1,dfx2
+        real(kind=dp)               :: oval
         
     !------------------- calc. lower//upper stencil bounds !    
 
@@ -294,20 +294,20 @@
         implicit none
 
     !------------------------------------------- arguments !
-        integer, intent(in)  :: npos,halo
-        integer, intent(in)  :: ipos,ivar
-        integer, intent(in)  :: wlim
-        real*8 , intent(in)  :: delx(1)
-        real*8 , intent(in)  :: oscl(:,:,:)
-        real*8 , intent(out) :: omin,omax
+        integer      , intent(in)   :: npos,halo
+        integer      , intent(in)   :: ipos,ivar
+        integer      , intent(in)   :: wlim
+        real(kind=dp), intent(in)   :: delx(1)
+        real(kind=dp), intent(in)   :: oscl(:,:,:)
+        real(kind=dp), intent(out)  :: omin,omax
 
     !------------------------------------------- variables !
-        integer :: hpos
-        integer :: head,tail
-        integer :: imin,imax
-        real*8  :: delh
-        real*8  :: dfx1,dfx2
-        real*8  :: oval
+        integer                     :: hpos
+        integer                     :: head,tail
+        integer                     :: imin,imax
+        real(kind=dp)               :: delh
+        real(kind=dp)               :: dfx1,dfx2
+        real(kind=dp)               :: oval
     
     !------------------- calc. lower//upper stencil bounds !    
 


### PR DESCRIPTION
- Uses `real(kind=dp)` in place of `real*8` for better cross-compiler compatibility.
- Adds `ppr_1d.F90` to allow for compiling without `-cpp` flag.
- Slope-limiter reduction: `PQM => PPM => PLM` to help suppress stair-step patterns near discontinuities w H/O methods.